### PR TITLE
feat(cli): add `--json` flag to print outputs in json format

### DIFF
--- a/crates/txtx-cli/src/cli/mod.rs
+++ b/crates/txtx-cli/src/cli/mod.rs
@@ -150,6 +150,9 @@ pub struct ExecuteRunbook {
     /// Execute the runbook with supervision via the terminal console (coming soon)
     #[arg(long = "terminal", short = 't', action=ArgAction::SetTrue, group = "execution_mode")]
     pub term_console: bool,
+    /// When running in unsupervised mode, print outputs in JSON format
+    #[arg(long = "json", action=ArgAction::SetTrue, requires="unsupervised")]
+    pub json: bool,
     /// Explain how the runbook will be executed.
     #[arg(long = "explain", action=ArgAction::SetTrue)]
     pub explain: bool,


### PR DESCRIPTION
This is still a bit janky because we don't have a `--quiet` mode to silence the other console updates, but with this flag we format the main outputs to json.

Just the JSON portion of the output can be parsed via `| sed -n '/{/,$p'` (on mac, at least). Then, you can pipe to `jq` and manipulate the outputs as needed. This can enable things like the following.

Runbook:
```hcl
runtime "addon::bitcoin" {
}

action "my_script" "bitcoin::encode_script" {
    instructions = [
        bitcoin::op_dup(),
        bitcoin::op_hash160(),
        bitcoin::op_pushdata(20, "55ae51684c43435da751ac8d2173b2652eb64105"),
        bitcoin::op_equalverify(),
        bitcoin::op_checksig()
    ]
}

output "out" {
    value = action.my_script
}
```
Terminal:
```bash
> txtx run btc.tx -u --json                                             

→ Processing file 'btc.tx'
✓ 'btc.tx' successfully checked
→ Starting runbook 'btc.tx' execution in unsupervised mode
default Outputs: 
{
  "out": [
    "0x76a91455ae51684c43435da751ac8d2173b2652eb6410588ac"
  ]
}
```
So instead, parse the json and send it to btcdeb, like so:
```bash
> txtx run btc.tx -u --json | sed -n '/{/,$p' | jq -r ".out[0]" | btcdeb
error: Operation not valid with the current stack size
script                                   |  stack 
-----------------------------------------+--------
OP_HASH160                               | 
55ae51684c43435da751ac8d2173b2652eb64105 | 
OP_EQUALVERIFY                           | 
OP_CHECKSIG                              | 
```