### PR TITLE
Working solana-sdk zeroize version fix 

### DIFF
--- a/addons/solana/Cargo.toml
+++ b/addons/solana/Cargo.toml
@@ -15,6 +15,8 @@ bincode = "1.3"
 
 #solana-sdk = "2.0.8"
 #solana-sdk = { path = "../../../solana/sdk" }
+#solana-sdk = { git = "https://github.com/txtx/solana", branch = "zeroize-fix", subdir = "solana/sdk" }
+#solana-client = { git = "https://github.com/txtx/solana", branch = "zeroize-fix", subdir = "solana/client" }
 solana-sdk = { git = "https://github.com/radicleart/solana", branch = "zeroize_fix", subdir = "solana/sdk" }
 # solana-client = { git = "https://github.com/radicleart/solana", branch = "zeroize_fix", subdir = "solana/client" }
 


### PR DESCRIPTION
Couldn't get the txtx forks of solana, curve25519-dalek to work with the fix i made for the zeroize dependency by forking the two projects into my own github space.

Pushing this PR as a fall back / working example.

```
cargo clean
cargo txtx-install
```

runs with this config.