### PR TITLE
Hardhat Support

### DIFF
--- a/addons/evm/src/codec/foundry.rs
+++ b/addons/evm/src/codec/foundry.rs
@@ -116,8 +116,8 @@ pub struct FoundryConfig {
 impl FoundryConfig {
     pub fn get_compiled_output(
         &self,
-        contract_filename: &str,
         contract_name: &str,
+        contract_filename: &str,
         profile_name: Option<&str>,
     ) -> Result<FoundryCompiledOutputJson, String> {
         let profile_name = profile_name.unwrap_or("default");
@@ -127,7 +127,7 @@ impl FoundryConfig {
         let mut path = PathBuf::from_str(&self.toml_path).unwrap();
         path.pop();
         path.push(&format!("{}", profile.out));
-        path.push(&format!("{}.sol", contract_filename));
+        path.push(contract_filename);
         path.push(&format!("{}.json", contract_name));
 
         let bytes = std::fs::read(&path).map_err(|e| {

--- a/addons/evm/src/codec/hardhat.rs
+++ b/addons/evm/src/codec/hardhat.rs
@@ -1,0 +1,182 @@
+use alloy::json_abi::JsonAbi;
+use std::{collections::HashMap, path::PathBuf};
+
+const BUILD_INFO_DIR: &str = "build-info";
+
+#[derive(Clone, Debug)]
+pub struct HardhatBuildArtifacts {
+    pub compiled_contract_path: String,
+    pub artifacts: HardhatContractArtifacts,
+    pub build_info: HardhatContractBuildInfo,
+}
+
+impl HardhatBuildArtifacts {
+    pub fn new(
+        artifacts_path: PathBuf,
+        contract_source_path: &str,
+        contract_name: &str,
+    ) -> Result<Self, String> {
+        let build_info =
+            HardhatContractBuildInfo::new(&artifacts_path, contract_source_path, contract_name)?;
+
+        let mut compiled_contract_path = artifacts_path;
+        compiled_contract_path.push(contract_source_path);
+
+        let contract_artifacts =
+            HardhatContractArtifacts::new(compiled_contract_path.clone(), contract_name)?;
+
+        Ok(Self {
+            compiled_contract_path: compiled_contract_path.to_str().unwrap().to_string(),
+            artifacts: contract_artifacts,
+            build_info,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+/// The <hash>.json file found in <root>/<artifacts-dir>/build-info folder of a hardhat project
+pub struct HardhatContractBuildInfo {
+    pub solc_long_version: String,
+    pub input: HardhatContractBuildInfoInput,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HardhatContractBuildInfoInput {
+    pub sources: HashMap<String, HardhatContractBuildInfoSource>,
+    pub settings: HardhatContractSettings,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HardhatContractBuildInfoSource {
+    pub content: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HardhatContractSettings {
+    pub evm_version: String,
+    pub optimizer: HardhatContractOptimizerSettings,
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HardhatContractOptimizerSettings {
+    pub enabled: bool,
+    pub runs: u64,
+}
+
+impl HardhatContractBuildInfo {
+    pub fn new(
+        artifacts_path: &PathBuf,
+        contract_source_path: &str,
+        contract_name: &str,
+    ) -> Result<Self, String> {
+        let build_info_file_hash: String = HardhatContractDebugFile::get_dbg_file_hash(
+            &artifacts_path,
+            contract_source_path,
+            contract_name,
+        )?;
+
+        let mut contract_build_info_path = artifacts_path.clone();
+        contract_build_info_path.push(&BUILD_INFO_DIR);
+        contract_build_info_path.push(&build_info_file_hash);
+
+        let bytes = std::fs::read(&contract_build_info_path).map_err(|e| {
+            format!(
+                "invalid hardhat build info location {}: {}",
+                &contract_build_info_path.to_str().unwrap_or(""),
+                e
+            )
+        })?;
+
+        let build_info: HardhatContractBuildInfo = serde_json::from_slice(&bytes).map_err(|e| {
+            format!(
+                "invalid hardhat build info at location {}: {}",
+                &contract_build_info_path.to_str().unwrap_or(""),
+                e
+            )
+        })?;
+
+        Ok(build_info)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+/// The <root>/<sources-dir>/<sol-filename>/<contract_name>.json file containing the compiled contract artifacts
+pub struct HardhatContractArtifacts {
+    pub abi: JsonAbi,
+    pub bytecode: String,
+    pub deployed_bytecode: String,
+    pub source_name: String,
+    pub contract_name: String,
+}
+
+impl HardhatContractArtifacts {
+    pub fn new(mut compiled_contract_path: PathBuf, contract_name: &str) -> Result<Self, String> {
+        compiled_contract_path.push(&format!("{}.json", contract_name));
+
+        let bytes = std::fs::read(&compiled_contract_path).map_err(|e| {
+            format!(
+                "invalid hardhat artifacts location {}: {}",
+                &compiled_contract_path.to_str().unwrap_or(""),
+                e
+            )
+        })?;
+
+        let artifacts: HardhatContractArtifacts = serde_json::from_slice(&bytes).map_err(|e| {
+            format!(
+                "invalid hardhat artifacts at location {}: {}",
+                &compiled_contract_path.to_str().unwrap_or(""),
+                e
+            )
+        })?;
+
+        Ok(artifacts)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+// The <root>/<sources-dir>/<sol-filename>/<contract_name>.dbg.json file containing the location of the contract's build info.
+pub struct HardhatContractDebugFile {
+    build_info: String,
+}
+
+impl HardhatContractDebugFile {
+    pub fn get_dbg_file_hash(
+        artifacts_path: &PathBuf,
+        contract_source_path: &str,
+        contract_name: &str,
+    ) -> Result<String, String> {
+        let mut contract_db_json_path = artifacts_path.clone();
+        contract_db_json_path.push(contract_source_path);
+        contract_db_json_path.push(&format!("{}.dbg.json", contract_name));
+
+        let bytes = std::fs::read(&contract_db_json_path).map_err(|e| {
+            format!(
+                "invalid hardhat debug artifacts location {}: {}",
+                &contract_db_json_path.to_str().unwrap_or(""),
+                e
+            )
+        })?;
+
+        let dbg: HardhatContractDebugFile = serde_json::from_slice(&bytes).map_err(|e| {
+            format!(
+                "invalid hardhat debug artifacts at location {}: {}",
+                &contract_db_json_path.to_str().unwrap_or(""),
+                e
+            )
+        })?;
+        let build_info_parts: Vec<&str> = dbg.build_info.split("/").collect();
+        let hash = build_info_parts.last().ok_or(format!(
+            "could not find hardhat build info for contract {}.sol/{}",
+            contract_db_json_path.to_str().unwrap(),
+            contract_name
+        ))?;
+
+        Ok(hash.to_string())
+    }
+}

--- a/addons/evm/src/codec/mod.rs
+++ b/addons/evm/src/codec/mod.rs
@@ -1,5 +1,6 @@
 pub mod crypto;
 pub mod foundry;
+pub mod hardhat;
 
 use crate::commands::actions::get_expected_address;
 use crate::constants::{GAS_PRICE, MAX_FEE_PER_GAS, MAX_PRIORITY_FEE_PER_GAS};

--- a/addons/evm/src/constants.rs
+++ b/addons/evm/src/constants.rs
@@ -57,6 +57,8 @@ pub const DEFAULT_MESSAGE: &str =
     "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks.";
 pub const DEFAULT_HARDHAT_ARTIFACTS_DIR: &str = "artifacts";
 pub const DEFAULT_HARDHAT_SOURCE_DIR: &str = "contracts";
+pub const DEFAULT_FOUNDRY_MANIFEST_PATH: &str = "foundry.toml";
+pub const DEFAULT_FOUNDRY_PROFILE: &str = "default";
 
 // Actions items keys
 pub const ACTION_ITEM_CHECK_BALANCE: &str = "check_balance";

--- a/addons/evm/src/constants.rs
+++ b/addons/evm/src/constants.rs
@@ -55,6 +55,8 @@ pub const TRANSACTION_COST: &str = "transaction_cost";
 pub const DEFAULT_CONFIRMATIONS_NUMBER: u64 = 1;
 pub const DEFAULT_MESSAGE: &str =
     "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks.";
+pub const DEFAULT_HARDHAT_ARTIFACTS_DIR: &str = "artifacts";
+pub const DEFAULT_HARDHAT_SOURCE_DIR: &str = "contracts";
 
 // Actions items keys
 pub const ACTION_ITEM_CHECK_BALANCE: &str = "check_balance";

--- a/addons/evm/src/functions.rs
+++ b/addons/evm/src/functions.rs
@@ -574,7 +574,6 @@ impl FunctionImplementation for GetHardhatDeploymentArtifacts {
         let optimizer_runs = Value::integer(build_info.input.settings.optimizer.runs as i128);
         let evm_version = Value::string(build_info.input.settings.evm_version);
         let project_root = Value::string(compiled_contract_path.to_string());
-        // let foundry_config = Value::buffer(serde_json::to_vec(&config).unwrap());
 
         let obj_props = ObjectType::from(vec![
             ("bytecode", bytecode),
@@ -587,7 +586,6 @@ impl FunctionImplementation for GetHardhatDeploymentArtifacts {
             ("optimizer_runs", optimizer_runs),
             ("evm_version", evm_version),
             ("project_root", project_root),
-            // ("foundry_config", foundry_config),
         ]);
 
         Ok(Value::object(obj_props.inner()))

--- a/addons/evm/src/tests/fixtures/foundry/runbooks/deployments/simple-storage.tx
+++ b/addons/evm/src/tests/fixtures/foundry/runbooks/deployments/simple-storage.tx
@@ -9,7 +9,7 @@ signer "alice" "evm::secret_key" {
 
 action "deploy_simple_storage" "evm::deploy_contract_create2" {
     description = "Deploy SimpleStorage"
-    contract = evm::get_contract_from_foundry_project("foundry.toml", "SimpleStorage")
+    contract = evm::get_contract_from_foundry_project("SimpleStorage")
     constructor_args = [14]
     salt = "0x0000000000000000000000000000000000000000177317f7617d575e615800c6"
     confirmations = 1

--- a/addons/sp1/examples/fibonacci/runbooks/usage/prover/inputs.tx
+++ b/addons/sp1/examples/fibonacci/runbooks/usage/prover/inputs.tx
@@ -5,5 +5,5 @@ variable "n" {
 
 variable "fibonacci_contract" {
     description = "The fibonacci contrat artifacts"
-    value = evm::get_contract_from_foundry_project("contracts/foundry.toml", "Fibonacci")
+    value = evm::get_contract_from_foundry_project("Fibonacci", "contracts/foundry.toml")
 }

--- a/addons/sp1/examples/fibonacci/runbooks/usage/prover/main.tx
+++ b/addons/sp1/examples/fibonacci/runbooks/usage/prover/main.tx
@@ -27,7 +27,7 @@ action "fibonacci_proof" "sp1::create_proof" {
 
 action "fibonacci_verifier_contract" "evm::deploy_contract_create2" {
     description = "Deploy the Fibonacci verifier contract"
-    contract = evm::get_contract_from_foundry_project("contracts/foundry.toml", "Fibonacci")
+    contract = evm::get_contract_from_foundry_project("Fibonacci", "contracts/foundry.toml")
     constructor_args = [
         evm::address(input.sp1_verifier_address), 
         evm::bytes32(action.fibonacci_proof.verification_key)

--- a/addons/stacks/src/constants.rs
+++ b/addons/stacks/src/constants.rs
@@ -30,6 +30,7 @@ pub const DEFAULT_MAINNET_BACKOFF: u64 = 15000;
 pub const DEFAULT_CONFIRMATIONS_NUMBER: u64 = 1;
 pub const DEFAULT_MESSAGE: &str =
     "The Times 03/Jan/2009 Chancellor on brink of second bailout for banks.";
+pub const DEFAULT_CLARINET_MANIFEST_PATH: &str = "Clarinet.toml";
 
 // Actions items keys
 pub const ACTION_ITEM_CHECK_BALANCE: &str = "check_balance";

--- a/addons/stacks/src/functions.rs
+++ b/addons/stacks/src/functions.rs
@@ -2,7 +2,7 @@ use std::collections::BTreeMap;
 
 use crate::{
     codec::cv::value_to_cv,
-    constants::{NAMESPACE, SIGNER},
+    constants::{DEFAULT_CLARINET_MANIFEST_PATH, NAMESPACE, SIGNER},
     typing::{DEPLOYMENT_ARTIFACTS_TYPE, STACKS_CV_ERR, STACKS_POST_CONDITIONS},
 };
 use clarity::vm::{
@@ -556,17 +556,24 @@ lazy_static! {
             RetrieveClarinetContract => {
                 name: "get_contract_from_clarinet_project",
                 documentation: "`stacks::get_contract_from_clarinet_project` retrieves the source of a contract present in a Clarinet manifest.",
-                example: indoc! {r#"// Coming soon "#},
+                example: indoc! {r#"
+                variable "contract_source" {
+                    value = stacks::get_contract_from_clarinet_project("my-contract")
+                }
+                output "contract_source" {
+                    value = variable.contract_source
+                }
+                "#},
                 inputs: [
-                    clarinet_manifest_path: {
-                        documentation: "The path of the Clarinet toml file.",
-                        typing: vec![Type::string()],
-                        optional: false
-                    },
                     contract_name: {
                         documentation: "Contract name of the contract source to fetch.",
                         typing: vec![Type::string()],
                         optional: false
+                    },
+                    clarinet_manifest_path: {
+                        documentation: "The path of the Clarinet.toml file. Defaults to `./Clarinet.toml`.",
+                        typing: vec![Type::string()],
+                        optional: true
                     }
                 ],
                 output: {
@@ -1221,8 +1228,9 @@ impl FunctionImplementation for RetrieveClarinetContract {
         args: &Vec<Value>,
     ) -> Result<Value, Diagnostic> {
         arg_checker(fn_spec, args)?;
-        let clarinet_toml_path = args.get(0).unwrap().as_string().unwrap();
-        let contract_key = args.get(1).unwrap().as_string().unwrap();
+        let contract_key = args.get(0).unwrap().as_string().unwrap();
+        let clarinet_toml_path =
+            args.get(1).and_then(|v| v.as_string()).unwrap_or(DEFAULT_CLARINET_MANIFEST_PATH);
 
         let mut clarinet_manifest =
             auth_ctx.workspace_location.get_parent_location().map_err(|e| {

--- a/crates/txtx-addon-kit/src/types/types.rs
+++ b/crates/txtx-addon-kit/src/types/types.rs
@@ -575,6 +575,32 @@ impl Value {
 //     }
 // }
 
+pub struct ObjectType {
+    map: IndexMap<String, Value>,
+}
+impl ObjectType {
+    pub fn new() -> Self {
+        ObjectType { map: IndexMap::new() }
+    }
+
+    pub fn from(default: Vec<(&str, Value)>) -> Self {
+        let mut map = IndexMap::new();
+        for (key, value) in default {
+            map.insert(key.to_string(), value);
+        }
+        ObjectType { map }
+    }
+
+    pub fn insert(&mut self, key: &str, value: Value) -> &mut Self {
+        self.map.insert(key.to_string(), value);
+        self
+    }
+
+    pub fn inner(&self) -> IndexMap<String, Value> {
+        self.map.clone()
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, PartialEq)]
 pub struct AddonData {
     pub bytes: Vec<u8>,

--- a/crates/txtx-core/src/eval/mod.rs
+++ b/crates/txtx-core/src/eval/mod.rs
@@ -873,20 +873,30 @@ pub fn eval_expression(
             };
 
             let attribute = components.pop_front().unwrap_or("value".into());
-            // this is a bit hacky. in some cases, our outputs are nested in a "value", but we don't want the user
-            // to have to provide it. if that's the case, the above line consumed an attribute we want to use and
-            // didn't actually use the default "value" key. so if fetching the provided attribute key yields no
-            // results, fetch "value", and add our attribute back to the list of components
-            match res.outputs.get(&attribute).or(res.outputs.get("value")) {
+
+            match res.outputs.get(&attribute) {
                 Some(output) => {
                     if let Some(_) = output.as_object() {
-                        components.push_front(attribute);
                         output.get_keys_from_object(components)?
                     } else {
                         output.clone()
                     }
                 }
-                None => return Ok(ExpressionEvaluationStatus::DependencyNotComputed),
+                // this is a bit hacky. in some cases, our outputs are nested in a "value" key, but we don't want the user
+                // to have to provide that key. if that's the case, the above line consumed an attribute we want to use and
+                // didn't actually use the default "value" key. so if fetching the provided attribute key yields no
+                // results, fetch "value", and add our attribute back to the list of components
+                None => match res.outputs.get("value") {
+                    Some(output) => {
+                        if let Some(_) = output.as_object() {
+                            components.push_front(attribute);
+                            output.get_keys_from_object(components)?
+                        } else {
+                            output.clone()
+                        }
+                    }
+                    None => return Ok(ExpressionEvaluationStatus::DependencyNotComputed),
+                },
             }
         }
         // Represents an operation which applies a unary operator to an expression.

--- a/examples/stacks/sample/runbooks/deployments/deploy-abcde.tx
+++ b/examples/stacks/sample/runbooks/deployments/deploy-abcde.tx
@@ -24,7 +24,7 @@ action "deploy_contract_a" "stacks::deploy_contract" {
     // Description of the deployment
     description = "Deploy contract-a"
     // Load contract
-    contract = stacks::get_contract_from_clarinet_project(input.clarinet_manifest_path, "contract-a")
+    contract = stacks::get_contract_from_clarinet_project("contract-a")
     // Signer
     signer = signer.operator
     // Set contract instance name, update downstream dependencies
@@ -35,7 +35,7 @@ action "deploy_contract_b" "stacks::deploy_contract" {
     // Description of the deployment
     description = "Deploy contract-b"
     // Load contract
-    contract = stacks::get_contract_from_clarinet_project(input.clarinet_manifest_path, "contract-b")
+    contract = stacks::get_contract_from_clarinet_project("contract-b")
     // Signer
     signer = signer.operator
     // Set contract instance name, update downstream dependencies
@@ -46,7 +46,7 @@ action "deploy_contract_c" "stacks::deploy_contract" {
     // Description of the deployment
     description = "Deploy contract-c"
     // Load contract
-    contract = stacks::get_contract_from_clarinet_project(input.clarinet_manifest_path, "contract-c")
+    contract = stacks::get_contract_from_clarinet_project("contract-c")
     // Signer
     signer = signer.operator
     // Set contract instance name, update downstream dependencies
@@ -57,7 +57,7 @@ action "deploy_contract_d" "stacks::deploy_contract" {
     // Description of the deployment
     description = "Deploy contract-dd"
     // Load contract
-    contract = stacks::get_contract_from_clarinet_project(input.clarinet_manifest_path, "contract-d")
+    contract = stacks::get_contract_from_clarinet_project("contract-d")
     // Signer
     signer = signer.operator
     // Set contract instance name, update downstream dependencies
@@ -68,7 +68,7 @@ action "deploy_contract_e" "stacks::deploy_contract" {
     // Description of the deployment
     description = "Deploy contract-d"
     // Load contract
-    contract = stacks::get_contract_from_clarinet_project(input.clarinet_manifest_path, "contract-d")
+    contract = stacks::get_contract_from_clarinet_project("contract-d")
     // Signer
     signer = signer.operator
     // Set contract instance name, update downstream dependencies

--- a/examples/stacks/sample/runbooks/deployments/deploy-token.tx
+++ b/examples/stacks/sample/runbooks/deployments/deploy-token.tx
@@ -16,7 +16,7 @@ signer "operator" "stacks::secret_key" {
 
 action "deploy_contract_a" "stacks::deploy_contract" {
     description = "Deploy contract-a"
-    contract = stacks::get_contract_from_clarinet_project(input.clarinet_manifest_path, "token")
+    contract = stacks::get_contract_from_clarinet_project("token")
     signer = signer.operator
 }
 


### PR DESCRIPTION
## ⚠️ Breaking Changes
 - `get_contract_from_clarinet_project` now has the contract name _then_ the Clarinet.toml path. Also, the Clarinet.toml path is optional, defaulting to `./Clarinet.toml`:
```hcl
variable "contract_source" {
    value = stacks::get_contract_from_clarinet_project("my-contract")
}
output "contract_source" {
    value = variable.contract_source
}
```
 - `get_contract_from_foundry_project` now has the following arguments:
   - contract name
   - contract file name - optional, defaults to `<ContractName>.sol`
   - foundry.toml path - optional, defaults to `./foundry.toml`
   - foundry profile - optional, defaults to `default`
```hcl
variable "contract_source" {
    value = stacks::get_contract_from_foundry_project("SimpleStorage")
}
output "contract_source" {
    value = variable.contract_source
}
```