### PR TITLE
change name of cookie from 'hanko' to 'nhost'

### DIFF
--- a/.github/workflows/push_main.yaml
+++ b/.github/workflows/push_main.yaml
@@ -93,14 +93,14 @@ jobs:
           echo INFURA_API_KEY=${{ secrets.INFURA_API_KEY }} >> .env
           cat .env
 
-      - name: Checkout Web UI
+      - name: Checkout Supervisor UI
         uses: actions/checkout@v4
         with:
           repository: txtx/txtx-supervisor-ui
           token: ${{ secrets.TXTX_ACCESS_TOKEN }} 
           path: txtx-supervisor-ui 
 
-      - name: Build .env file for Web UI
+      - name: Build .env file for Supervisor UI
         run: |
           cd txtx-supervisor-ui
           touch .env
@@ -109,10 +109,10 @@ jobs:
           cat .env
           cd ..
 
-      - name: Build Web UI
+      - name: Build Supervisor UI
         run: |
           cd txtx-supervisor-ui
-          npm i
+          npm run i
           npm run build
           cd ..
 

--- a/.github/workflows/push_main.yaml
+++ b/.github/workflows/push_main.yaml
@@ -105,6 +105,7 @@ jobs:
           cd txtx-web-ui
           touch .env
           echo ID_SERVICE_URL="https://id.txtx.run/proxy" >> .env
+          echo TXTX_DEV_NPM_READ_TOKEN="${{ secrets.TXTX_DEV_NPM_READ_TOKEN }}" >> .env
           cat .env
           cd ..
 

--- a/.github/workflows/push_main.yaml
+++ b/.github/workflows/push_main.yaml
@@ -96,13 +96,13 @@ jobs:
       - name: Checkout Web UI
         uses: actions/checkout@v4
         with:
-          repository: txtx/txtx-web-ui
+          repository: txtx/txtx-supervisor-ui
           token: ${{ secrets.TXTX_ACCESS_TOKEN }} 
-          path: txtx-web-ui 
+          path: txtx-supervisor-ui 
 
       - name: Build .env file for Web UI
         run: |
-          cd txtx-web-ui
+          cd txtx-supervisor-ui
           touch .env
           echo ID_SERVICE_URL="https://id.txtx.run/proxy" >> .env
           echo TXTX_DEV_NPM_READ_TOKEN="${{ secrets.TXTX_DEV_NPM_READ_TOKEN }}" >> .env
@@ -111,7 +111,7 @@ jobs:
 
       - name: Build Web UI
         run: |
-          cd txtx-web-ui
+          cd txtx-supervisor-ui
           npm i
           npm run build
           cd ..

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 /target
 .DS_Store
 .btcdeb_history
-crates/txtx-web-ui/node_modules
-crates/txtx-web-ui/.parcel-cache
 .env
 addons/evm/src/tests/fixtures/foundry/out/build-info
 addons/sp1/examples/fibonacci/contracts/lib

--- a/crates/txtx-cli/build.rs
+++ b/crates/txtx-cli/build.rs
@@ -4,9 +4,9 @@ fn main() {
         use npm_rs::*;
 
         println!("cargo:rerun-if-changed=build.rs");
-        println!("cargo:rerun-if-changed=../../../txtx-web-ui/src");
+        println!("cargo:rerun-if-changed=../../../txtx-supervisor-ui/src");
         let exit_status = NpmEnv::default()
-            .set_path(std::path::Path::new("../../../txtx-web-ui"))
+            .set_path(std::path::Path::new("../../../txtx-supervisor-ui"))
             .with_node_env(&NodeEnv::Production)
             .init_env()
             .install(None)

--- a/crates/txtx-cli/src/web_ui/cloud_relayer.rs
+++ b/crates/txtx-cli/src/web_ui/cloud_relayer.rs
@@ -81,7 +81,7 @@ pub async fn open_channel(
     graph_context: Data<GraphContext>,
 ) -> actix_web::Result<HttpResponse> {
     println!("POST /api/v1/channels");
-    let Some(cookie) = req.cookie("hanko") else {
+    let Some(cookie) = req.cookie("nhost") else {
         return Ok(HttpResponse::Unauthorized().body("No auth data provided"));
     };
 
@@ -162,7 +162,7 @@ pub async fn delete_channel(
     payload: Json<DeleteChannelRequest>,
 ) -> actix_web::Result<HttpResponse> {
     println!("DELETE /api/v1/channels");
-    let Some(cookie) = req.cookie("hanko") else {
+    let Some(cookie) = req.cookie("nhost") else {
         return Ok(HttpResponse::Unauthorized().body("No auth data provided"));
     };
 

--- a/crates/txtx-cli/src/web_ui/mod.rs
+++ b/crates/txtx-cli/src/web_ui/mod.rs
@@ -6,5 +6,5 @@ use rust_embed::RustEmbed;
 
 #[cfg(feature = "web_ui")]
 #[derive(RustEmbed)]
-#[folder = "../../../txtx-web-ui/dist/"]
+#[folder = "../../../txtx-supervisor-ui/dist/"]
 pub struct Asset;


### PR DESCRIPTION
This PR is in preparation of merging https://github.com/txtx/txtx-supervisor-ui/pull/51.

When that PR is merged the auth cookie will be named 'nhost' instead of 'hanko' as the authentication is being switched.