### PR TITLE
feat: draft txtx serve

### DIFF
--- a/addons/evm/src/signers/secret_key.rs
+++ b/addons/evm/src/signers/secret_key.rs
@@ -3,7 +3,6 @@ use alloy::network::{EthereumWallet, TransactionBuilder};
 use alloy::primitives::Address;
 use alloy_rpc_types::TransactionRequest;
 use std::collections::HashMap;
-use std::u64;
 use txtx_addon_kit::channel;
 use txtx_addon_kit::constants::SIGNATURE_APPROVED;
 use txtx_addon_kit::types::commands::CommandExecutionResult;

--- a/addons/evm/src/signers/web_wallet.rs
+++ b/addons/evm/src/signers/web_wallet.rs
@@ -44,7 +44,7 @@ lazy_static! {
                     expected_address: {
                         documentation: "The EVM address that is expected to connect to the Runbook execution. Omitting this field will allow any address to be used for this signer.",
                         typing: Type::string(),
-                        optional: false,
+                        optional: true,
                         tainting: true,
                         sensitive: true
                     }

--- a/crates/txtx-cli/src/cli/mod.rs
+++ b/crates/txtx-cli/src/cli/mod.rs
@@ -254,7 +254,7 @@ pub struct StartServer {
     #[arg(long = "output", conflicts_with = "output_json")]
     pub output: Option<String>,
     /// Set the port for hosting the web UI
-    #[arg(long = "port", short = 'p', default_value = DEFAULT_BINDING_PORT )]
+    #[arg(long = "port", short = 'p', default_value = SERVE_BINDING_PORT )]
     pub network_binding_port: u16,
     /// Set the port for hosting the web UI
     #[arg(long = "ip", short = 'i', default_value = DEFAULT_BINDING_ADDRESS )]

--- a/crates/txtx-cli/src/cli/mod.rs
+++ b/crates/txtx-cli/src/cli/mod.rs
@@ -329,13 +329,15 @@ async fn handle_command(
             lsp::run_lsp().await?;
         }
         Command::Cloud(cmd) => cloud::handle_auth_command(&cmd, ctx).await?,
-        Command::Serve(_cmd) => {
+        Command::Serve(cmd) => {
             warn!(ctx.expect_logger(), "The command `txtx serve` is experimental and will run for 30 minutes.");
-            let _ = crate::serve::start_server("0.0.0.0:18488", ctx).await.unwrap();
+            let addr = format!("{}:{}", cmd.network_binding_ip_address, cmd.network_binding_port);
+            let _ = crate::serve::start_server(&addr, ctx).await.unwrap();
             ctrlc::set_handler(move || {
                 std::process::exit(1);
             })
             .expect("Error setting Ctrl-C handler");
+            // Consider making the duration configurable or running indefinitely
             thread::sleep(std::time::Duration::new(1800, 0));
         }
     }

--- a/crates/txtx-cli/src/cli/mod.rs
+++ b/crates/txtx-cli/src/cli/mod.rs
@@ -1,7 +1,7 @@
 use atty::Stream;
 use clap::{ArgAction, Parser, Subcommand};
 use hiro_system_kit::{self, Logger};
-use runbooks::{DEFAULT_BINDING_ADDRESS, DEFAULT_BINDING_PORT};
+use runbooks::{DEFAULT_BINDING_ADDRESS, DEFAULT_BINDING_PORT, SERVE_BINDING_PORT};
 use std::{process, thread};
 
 mod cloud;

--- a/crates/txtx-cli/src/cli/runbooks/mod.rs
+++ b/crates/txtx-cli/src/cli/runbooks/mod.rs
@@ -61,6 +61,7 @@ use txtx_gql::Context as GqlContext;
 use web_ui::cloud_relayer::RelayerContext;
 
 pub const DEFAULT_BINDING_PORT: &str = "8488";
+pub const SERVE_BINDING_PORT: &str = "18488";
 pub const DEFAULT_BINDING_ADDRESS: &str = "localhost";
 
 pub fn get_lock_file_location(state_file_location: &FileLocation) -> FileLocation {

--- a/crates/txtx-cli/src/cli/runbooks/mod.rs
+++ b/crates/txtx-cli/src/cli/runbooks/mod.rs
@@ -11,15 +11,10 @@ use std::{
     sync::Arc,
 };
 use tokio::sync::RwLock;
-use txtx_addon_network_bitcoin::BitcoinNetworkAddon;
-use txtx_addon_network_evm::EvmNetworkAddon;
 #[cfg(feature = "ovm")]
 use txtx_addon_network_ovm::OvmNetworkAddon;
-use txtx_addon_network_stacks::StacksNetworkAddon;
-use txtx_addon_network_svm::SvmNetworkAddon;
 #[cfg(feature = "sp1")]
 use txtx_addon_sp1::Sp1Addon;
-use txtx_addon_telegram::TelegramAddon;
 use txtx_core::{
     kit::types::{commands::UnevaluatedInputsMap, stores::ValueStore},
     runbook::embedded_runbook::publishable::PublishableEmbeddedRunbookSpecification,
@@ -52,47 +47,21 @@ use txtx_core::{
         RunbookTopLevelInputsMap, SynthesizedChange,
     },
     start_supervised_runbook_runloop, start_unsupervised_runbook_runloop,
-    std::StdAddon,
     types::{ConstructDid, Runbook, RunbookSnapshotContext, RunbookSources},
 };
 
 use super::{CheckRunbook, Context, CreateRunbook, ExecuteRunbook, ListRunbooks, PublishRunbook};
 use crate::{
-    cli::templates::{build_manifest_data, build_runbook_data},
-    web_ui::{
+    cli::templates::{build_manifest_data, build_runbook_data}, get_addon_by_namespace, get_available_addons, web_ui::{
         self,
         cloud_relayer::{start_relayer_event_runloop, RelayerChannelEvent},
-    },
+    }
 };
 use txtx_gql::Context as GqlContext;
 use web_ui::cloud_relayer::RelayerContext;
 
 pub const DEFAULT_BINDING_PORT: &str = "8488";
 pub const DEFAULT_BINDING_ADDRESS: &str = "localhost";
-
-pub fn get_available_addons() -> Vec<Box<dyn Addon>> {
-    vec![
-        Box::new(StdAddon::new()),
-        Box::new(SvmNetworkAddon::new()),
-        Box::new(StacksNetworkAddon::new()),
-        Box::new(EvmNetworkAddon::new()),
-        Box::new(BitcoinNetworkAddon::new()),
-        Box::new(TelegramAddon::new()),
-        #[cfg(feature = "sp1")]
-        Box::new(Sp1Addon::new()),
-        #[cfg(feature = "ovm")]
-        Box::new(OvmNetworkAddon::new()),
-    ]
-}
-pub fn get_addon_by_namespace(namespace: &str) -> Option<Box<dyn Addon>> {
-    let available_addons = get_available_addons();
-    for addon in available_addons.into_iter() {
-        if namespace.starts_with(&format!("{}", addon.get_namespace())) {
-            return Some(addon);
-        }
-    }
-    None
-}
 
 pub fn get_lock_file_location(state_file_location: &FileLocation) -> FileLocation {
     let lock_file_name = format!("{}.lock", state_file_location.get_file_name().unwrap());

--- a/crates/txtx-cli/src/main.rs
+++ b/crates/txtx-cli/src/main.rs
@@ -1,3 +1,10 @@
+use txtx_addon_network_bitcoin::BitcoinNetworkAddon;
+use txtx_addon_network_evm::EvmNetworkAddon;
+use txtx_addon_network_stacks::StacksNetworkAddon;
+use txtx_addon_network_svm::SvmNetworkAddon;
+use txtx_addon_telegram::TelegramAddon;
+use txtx_core::{kit::Addon, std::StdAddon};
+
 mod macros;
 
 #[macro_use]
@@ -8,6 +15,32 @@ pub mod manifest;
 pub mod snapshots;
 pub mod term_ui;
 pub mod web_ui;
+pub mod serve;
+
+pub fn get_available_addons() -> Vec<Box<dyn Addon>> {
+    vec![
+        Box::new(StdAddon::new()),
+        Box::new(SvmNetworkAddon::new()),
+        Box::new(StacksNetworkAddon::new()),
+        Box::new(EvmNetworkAddon::new()),
+        Box::new(BitcoinNetworkAddon::new()),
+        Box::new(TelegramAddon::new()),
+        #[cfg(feature = "sp1")]
+        Box::new(Sp1Addon::new()),
+        #[cfg(feature = "ovm")]
+        Box::new(OvmNetworkAddon::new()),
+    ]
+}
+
+pub fn get_addon_by_namespace(namespace: &str) -> Option<Box<dyn Addon>> {
+    let available_addons = get_available_addons();
+    for addon in available_addons.into_iter() {
+        if namespace.starts_with(&format!("{}", addon.get_namespace())) {
+            return Some(addon);
+        }
+    }
+    None
+}
 
 fn main() {
     cli::main();

--- a/crates/txtx-cli/src/serve/mod.rs
+++ b/crates/txtx-cli/src/serve/mod.rs
@@ -127,7 +127,7 @@ pub struct ConstructRequest {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum RunbookExecutionStepState {
-    Suceeded,
+    Succeeded,
     Failed,
     Current,
     Next,

--- a/crates/txtx-cli/src/serve/mod.rs
+++ b/crates/txtx-cli/src/serve/mod.rs
@@ -256,7 +256,8 @@ pub async fn execute_runbook(
     let runbook_name = payload.name.clone();
     let runbook_description = Some(payload.description.clone());
     let runbook_source = reconstructed_source;
-    let dummy_location = FileLocation::from_path_string("/tmp/file.tx").unwrap();
+    let dummy_location = FileLocation::from_path_string("/tmp/file.tx")
+        .map_err(|e| Box::<dyn StdError>::from(e))?;
 
     let mut runbook_sources = RunbookSources::new();
     runbook_sources.add_source(runbook_name.clone(), dummy_location, runbook_source);

--- a/crates/txtx-cli/src/serve/mod.rs
+++ b/crates/txtx-cli/src/serve/mod.rs
@@ -1,0 +1,605 @@
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+use std::time::Duration;
+
+use actix_web::error::ErrorRequestTimeout;
+use actix_web::http::StatusCode;
+use juniper_actix::{graphql_handler, subscriptions};
+use juniper_graphql_ws::ConnectionConfig;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use tokio::sync::RwLock;
+use txtx_core::kit::channel;
+use txtx_core::kit::helpers::fs::FileLocation;
+use txtx_core::kit::types::frontend::{ActionItemRequest, ActionItemResponse, BlockEvent, ClientType, DiscoveryResponse};
+use txtx_core::kit::types::{AuthorizationContext, RunbookId};
+use txtx_core::kit::uuid::Uuid;
+use txtx_core::runbook::RunbookTopLevelInputsMap;
+use txtx_core::start_supervised_runbook_runloop;
+use txtx_core::types::{Runbook, RunbookSources};
+use txtx_gql::{new_graphql_schema, Context as GraphContext, GraphqlSchema};
+use actix_cors::Cors;
+use actix_web::dev::ServerHandle;
+use actix_web::http::header::{self};
+use actix_web::web::{self, Data, Json};
+use actix_web::{Error, HttpResponseBuilder, Responder};
+use actix_web::{middleware, App, HttpRequest, HttpResponse, HttpServer};
+use crate::cli::Context;
+use crate::get_addon_by_namespace;
+use crate::web_ui::cloud_relayer::{start_relayer_event_runloop, RelayerChannelEvent, RelayerContext};
+use serde::ser::StdError;
+use txtx_gql::Context as GqlContext;
+
+pub async fn start_server(
+    network_binding: &str,
+    ctx: &Context,
+) -> Result<ServerHandle, Box<dyn StdError>> {
+
+    info!(ctx.expect_logger(), "Starting server {}", network_binding);
+
+    let boxed_ctx = Data::new(ctx.clone());
+
+    let gql_context: Data<RwLock<Option<GqlContext>>> = Data::new(RwLock::new(None));
+
+    let server = HttpServer::new(move || {
+        App::new()
+            .app_data(gql_context.clone())
+            .app_data(Data::new(new_graphql_schema()))
+            .app_data(boxed_ctx.clone())
+            .wrap(
+                Cors::default()
+                    .allow_any_origin()
+                    .allowed_methods(vec!["POST", "GET", "OPTIONS", "DELETE"])
+                    .allowed_headers(vec![header::AUTHORIZATION, header::ACCEPT])
+                    .allowed_header(header::CONTENT_TYPE)
+                    .supports_credentials()
+                    .max_age(3600),
+            )
+            .wrap(middleware::Compress::default())
+            .wrap(middleware::Logger::default())
+            .service(
+                web::scope("/api/v1")
+                    .route("/runbooks/check", web::post().to(register_runbook))
+                    .route("/runbooks/run", web::post().to(execute_runbook))
+                    .route("/runbooks/run/state", web::get().to(execute_runbook))
+                    .route("/discovery", web::get().to(discovery)),
+            )
+            .route("/ping", web::get().to(check_service_health))
+            .service(
+                web::scope("/gql/v1")
+                    .route("/graphql?<request..>", web::get().to(get_graphql))
+                    .route("/graphql", web::post().to(post_graphql))
+                    .route("/subscriptions", web::get().to(subscriptions)),
+            )
+    })
+    .workers(5)
+    .bind(network_binding)?
+    .run();
+
+    let handle = server.handle();
+    tokio::spawn(server);
+
+    // Declare a pool of threads
+    // 
+
+    Ok(handle)
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct SimpleResponse {
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RunbookRegistrationRequest {
+    hcl_source: String
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RunbookRegistrationResponse {
+    runbook_uuid: Uuid
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct StartRunbookExecutionRequest {
+    id: String,
+    name: String,
+    description: String,
+    constructs: Vec<ConstructRequest>,
+    hcl_source_legacy: Option<String>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct ConstructRequest {
+    construct_type: String,
+    id: String,
+    description: String,
+    value: Option<JsonValue>,
+    action_id: Option<String>,
+    namespace: Option<String>,
+    inputs: Option<BTreeMap<String, JsonValue>>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunbookExecutionStepState {
+    Suceeded,
+    Failed,
+    Current,
+    Next,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RunbookExecutionStep {
+    state: RunbookExecutionStepState
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct RunbookExecutionStateResponse {
+    runbook_uuid: Uuid,
+    steps: Vec<RunbookExecutionStep>
+}
+
+pub async fn check_service_health(
+    req: HttpRequest,
+    ctx: Data<Context>,
+    // graph_context: Data<GraphContext>,
+) -> actix_web::Result<HttpResponse> {
+    info!(ctx.expect_logger(), "{} {}", req.method().as_str(), req.path());
+
+    let response = SimpleResponse {
+    };
+    Ok(HttpResponseBuilder::new(StatusCode::OK).json(response))
+}
+
+pub async fn register_runbook(
+    req: HttpRequest,
+    ctx: Data<Context>,
+    _payload: Json<RunbookRegistrationRequest>,
+    // relayer_context: Data<RelayerContext>,
+    // graph_context: Data<GraphContext>,
+) -> actix_web::Result<HttpResponse> {
+    info!(ctx.expect_logger(), "{} {}", req.method().as_str(), req.path());
+
+    let response = SimpleResponse {
+    };
+    Ok(HttpResponseBuilder::new(StatusCode::OK).json(response))
+}
+
+pub async fn execute_runbook(
+    req: HttpRequest,
+    ctx: Data<Context>,
+    payload: Json<StartRunbookExecutionRequest>,
+    // relayer_context: Data<RelayerContext>,
+    gql_context: Data<RwLock<Option<GraphContext>>>,
+) -> actix_web::Result<HttpResponse> {
+    info!(ctx.expect_logger(), "{} {}", req.method().as_str(), req.path());
+    
+    let mut reconstructed_source = "".to_string();
+    let mut required_addons = HashSet::new(); 
+    for construct in payload.constructs.iter() {
+        reconstructed_source.push_str(&construct.construct_type);
+        reconstructed_source.push_str(&format!(" \"{}\"", &construct.id));
+        if let Some(ref namespace) = construct.namespace {
+            required_addons.insert(namespace);
+        }
+        let command_id = match (&construct.namespace, &construct.action_id) {
+            (Some(namespace), Some(id)) => format!("\"{}::{}\"", namespace, id),
+            (None, Some(id)) => format!("\"{}\"", id),
+            (Some(namespace), None) => format!(" \"{}\"", namespace),
+            (None, None) => format!("")
+        };
+        reconstructed_source.push_str(&format!(" {} {{\n", &command_id));
+        if construct.construct_type.eq("variable") || construct.construct_type.eq("output") {
+            reconstructed_source.push_str(&format!("  description = \"{}\"\n", construct.description));
+            reconstructed_source.push_str(&format!("  editable = true\n"));
+
+            if let Some(ref value) = construct.value {
+                match value {
+                    JsonValue::Null => {
+                    }
+                    JsonValue::String(value) if value.starts_with("$") => {
+                        reconstructed_source.push_str(&format!("  value = {}\n", &value[1..]));
+                    }
+                    JsonValue::String(value) => {
+                        reconstructed_source.push_str(&format!("  value = \"{}\"\n", value));
+                    }
+                    JsonValue::Number(value) => {
+                        reconstructed_source.push_str(&format!("  value = {}\n", &value));
+                    }
+                    _ => unreachable!()
+                }
+            }
+        } else if construct.construct_type.eq("action") {
+            if let Some(ref inputs) = construct.inputs {
+                for (key, value) in inputs.iter() {
+                    match value {
+                        JsonValue::Null => {
+                        }
+                        JsonValue::String(value) if value.eq("null") => {
+                        }
+                        JsonValue::String(value) if value.starts_with("$") => {
+                            reconstructed_source.push_str(&format!("  {} = {}\n", key, &value[1..]));
+                        }
+                        JsonValue::String(value) => {
+                            reconstructed_source.push_str(&format!("  {} = \"{}\"\n", key, value));
+                        }
+                        JsonValue::Number(value) => {
+                            reconstructed_source.push_str(&format!("  {} = {}\n", key, &value));
+                        }
+                        _ => unreachable!()
+                    }
+                }
+            }
+        }
+        reconstructed_source.push_str(&format!("}}\n\n"));
+    }
+    for addon in required_addons.iter() {
+        reconstructed_source.push_str(&format!("addon \"{}\" {{\n", addon));
+        reconstructed_source.push_str(&format!(" chain_id = 11155111\n"));
+        reconstructed_source.push_str(&format!(" rpc_api_url = \"https://sepolia.infura.io/v3/a063e95957aa4fd29319b2a53c31d481\"\n"));
+        reconstructed_source.push_str(&format!("}}\n\n"));
+
+        reconstructed_source.push_str(&format!("signer \"account\" \"{}::web_wallet\" {{\n", addon));
+        reconstructed_source.push_str(&format!(" description = \"Account\"\n"));
+        reconstructed_source.push_str(&format!("}}\n\n"));
+    }
+    println!("{}", reconstructed_source);
+
+
+    let runbook_name = payload.name.clone();
+    let runbook_description = Some(payload.description.clone());
+    let runbook_source = reconstructed_source;
+    let dummy_location = FileLocation::from_path_string("/tmp/file.tx").unwrap();
+
+    let mut runbook_sources = RunbookSources::new();
+    runbook_sources.add_source(runbook_name.clone(), dummy_location, runbook_source);
+    let runbook_id = RunbookId { org: None, workspace: None, name: runbook_name.clone() };
+    let mut runbook = Runbook::new(runbook_id, runbook_description);
+
+    let runbook_inputs = RunbookTopLevelInputsMap::new();
+    let authorization_context = AuthorizationContext::empty();
+    runbook
+        .build_contexts_from_sources(
+            runbook_sources,
+            runbook_inputs,
+            authorization_context,
+            get_addon_by_namespace,
+        ).await
+        .unwrap();
+
+    runbook.enable_full_execution_mode();
+    info!(ctx.expect_logger(), "2");
+    let runbook_description = runbook.description.clone();
+    let registered_addons = runbook
+        .runtime_context
+        .addons_context
+        .registered_addons
+        .keys()
+        .map(|k| k.clone())
+        .collect::<Vec<_>>();
+    let (block_tx, block_rx) = channel::unbounded::<BlockEvent>();
+    let (block_broadcaster, _) = tokio::sync::broadcast::channel(5);
+    let (action_item_updates_tx, _action_item_updates_rx) =
+        channel::unbounded::<ActionItemRequest>();
+    let (action_item_events_tx, action_item_events_rx) = channel::unbounded::<ActionItemResponse>();
+    let block_store = Arc::new(RwLock::new(BTreeMap::new()));
+    let (kill_loops_tx, kill_loops_rx) = channel::bounded(1);
+    let (relayer_channel_tx, relayer_channel_rx) = channel::unbounded();
+
+    let moved_block_tx = block_tx.clone();
+    let moved_kill_loops_tx = kill_loops_tx.clone();
+    let moved_ctx = ctx.clone();
+
+    let _ = hiro_system_kit::thread_named("Runbook Runloop").spawn(move || {
+        let runloop_future = start_supervised_runbook_runloop(
+            &mut runbook,
+            moved_block_tx,
+            action_item_updates_tx,
+            action_item_events_rx,
+        );
+        if let Err(diags) = hiro_system_kit::nestable_block_on(runloop_future) {
+            for diag in diags.iter() {
+                error!(moved_ctx.expect_logger(), "Runbook execution failed: {}", diag.message);
+            }
+            // if let Err(e) = write_runbook_transient_state(&mut runbook, moved_runbook_state) {
+            //     println!("{} Failed to write transient runbook state: {}", red!("x"), e);
+            // };
+        } else {
+            // if let Err(e) = write_runbook_state(&mut runbook, moved_runbook_state) {
+            //     println!("{} Failed to write runbook state: {}", red!("x"), e);
+            // };
+        }
+        if let Err(_e) = moved_kill_loops_tx.send(true) {
+            // std::process::exit(1);
+        }
+    });
+
+    // start web ui server
+    {
+        let mut gql_context = gql_context.write().await;
+        *gql_context = Some(GqlContext {
+            protocol_name: runbook_name.clone(),
+            runbook_name: runbook_name.clone(),
+            registered_addons,
+            runbook_description,
+            block_store: block_store.clone(),
+            block_broadcaster: block_broadcaster.clone(),
+            action_item_events_tx: action_item_events_tx.clone(),
+        });
+    }
+    
+    let channel_data = Arc::new(RwLock::new(None));
+    let _relayer_context = RelayerContext {
+        relayer_channel_tx: relayer_channel_tx.clone(),
+        channel_data: channel_data.clone(),
+    };
+
+    let moved_relayer_channel_tx = relayer_channel_tx.clone();
+    let moved_kill_loops_tx = kill_loops_tx.clone();
+    let moved_action_item_events_tx = action_item_events_tx.clone();
+    let _ = hiro_system_kit::thread_named("Relayer Interaction").spawn(move || {
+        let future = start_relayer_event_runloop(
+            channel_data,
+            relayer_channel_rx,
+            moved_relayer_channel_tx,
+            moved_action_item_events_tx,
+            moved_kill_loops_tx,
+        );
+        hiro_system_kit::nestable_block_on(future)
+    });
+
+    let moved_relayer_channel_tx = relayer_channel_tx.clone();
+    let _block_store_handle = tokio::spawn(async move {
+        loop {
+            if let Ok(mut block_event) = block_rx.try_recv() {
+                let mut block_store = block_store.write().await;
+                let mut do_propagate_event = true;
+                match block_event.clone() {
+                    BlockEvent::Action(new_block) => {
+                        let len = block_store.len();
+                        block_store.insert(len, new_block.clone());
+                    }
+                    BlockEvent::Clear => {
+                        *block_store = BTreeMap::new();
+                    }
+                    BlockEvent::UpdateActionItems(updates) => {
+                        // for action item updates, track if we actually changed anything before propagating the event
+                        do_propagate_event = false;
+                        let mut filtered_updates = vec![];
+                        for update in updates.iter() {
+                            for (_, block) in block_store.iter_mut() {
+                                let did_update = block.apply_action_item_updates(update.clone());
+                                if did_update {
+                                    do_propagate_event = true;
+                                    filtered_updates.push(update.clone());
+                                }
+                            }
+                        }
+                        block_event = BlockEvent::UpdateActionItems(filtered_updates);
+                    }
+                    BlockEvent::Modal(new_block) => {
+                        let len = block_store.len();
+                        block_store.insert(len, new_block.clone());
+                    }
+                    BlockEvent::ProgressBar(new_block) => {
+                        let len = block_store.len();
+                        block_store.insert(len, new_block.clone());
+                    }
+                    BlockEvent::UpdateProgressBarStatus(update) => block_store
+                        .iter_mut()
+                        .filter(|(_, b)| b.uuid == update.progress_bar_uuid)
+                        .for_each(|(_, b)| {
+                            b.update_progress_bar_status(&update.construct_did, &update.new_status)
+                        }),
+                    BlockEvent::UpdateProgressBarVisibility(update) => block_store
+                        .iter_mut()
+                        .filter(|(_, b)| b.uuid == update.progress_bar_uuid)
+                        .for_each(|(_, b)| b.visible = update.visible),
+                    BlockEvent::RunbookCompleted => {
+                        println!("\n{}", green!("Runbook complete!"));
+                        break;
+                    }
+                    BlockEvent::Error(new_block) => {
+                        let len = block_store.len();
+                        block_store.insert(len, new_block.clone());
+                    }
+                    BlockEvent::Exit => break,
+                }
+
+                if do_propagate_event {
+                    let _ = block_broadcaster.send(block_event.clone());
+                    let _ = moved_relayer_channel_tx
+                        .send(RelayerChannelEvent::ForwardEventToRelayer(block_event.clone()));
+                }
+            }
+
+            tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+            // println!("waiting for next block event");
+        }
+    });
+
+    let _ = hiro_system_kit::thread_named("Kill Runloops Thread")
+        .spawn(move || {
+            let future = async {
+                match kill_loops_rx.recv() {
+                    Ok(_) => {
+                        let _ = relayer_channel_tx.send(RelayerChannelEvent::Exit);
+                        let _ = block_tx.send(BlockEvent::Exit);
+                    }
+                    Err(_) => {}
+                };
+            };
+
+            hiro_system_kit::nestable_block_on(future)
+        })
+        .unwrap();
+
+    info!(ctx.expect_logger(), "Attempt to initialize execution channel");
+    // let token = "000000";
+    // let client = reqwest::Client::new();
+    // let path = format!("{}/api/v1/channels", "http://127.0.0.1:8489");
+
+    // let totp = auth_token_to_totp(token).get_secret_base32();
+    // let uuid = Uuid::new_v4();
+
+    // use base58::ToBase58;
+    // let slug = uuid.as_bytes().to_base58()[0..8].to_string();
+
+    // let block_store = gql_context.block_store.read().await.clone();
+    // let payload = OpenChannelRequest {
+    //     runbook_name: gql_context.runbook_name.clone(),
+    //     runbook_description: gql_context.runbook_description.clone(),
+    //     registered_addons: gql_context.registered_addons.clone(),
+    //     block_store: block_store.clone(),
+    //     uuid: uuid.clone(),
+    //     slug: slug.clone(),
+    //     operating_token: token.to_string(),
+    //     totp: totp.clone(),
+    // };
+
+    // let res = client
+    //     .post(path)
+    //     .bearer_auth(token)
+    //     .json(&payload)
+    //     .send()
+    //     .await
+    //     .map_err(ErrorInternalServerError)?;
+
+    // if let Err(e) = res.error_for_status_ref() {
+    //     let msg = res.text().await.unwrap_or_default();
+    //     error!(ctx.expect_logger(), "Channel creation failed: {}", msg);
+    //     return Ok(HttpResponseBuilder::new(
+    //         StatusCode::from_u16(e.status().map(|s| s.as_u16()).unwrap_or(500))
+    //             .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+    //     )
+    //     .json(json!({
+    //         "error": msg
+    //     })));
+    // }
+
+    // let body = match res.status() {
+    //     ReqwestStatusCode::OK => {
+    //         res.json::<OpenChannelResponse>().await.map_err(ErrorInternalServerError)?
+    //     }
+    //     _ => return Ok(HttpResponse::InternalServerError().body("Internal Server Error")),
+    // };
+
+    // let _ = relayer_context.relayer_channel_tx.send(RelayerChannelEvent::OpenChannel(
+    //     ChannelData::new(
+    //         token.to_string(),
+    //         totp.clone(),
+    //         slug.clone(),
+    //         body.clone(),
+    //         // &graph_context.action_item_events_tx,
+    //     ),
+    // ));
+
+    // info!(ctx.expect_logger(), "{:?}", body);
+
+    let response = SimpleResponse {
+    };
+    Ok(HttpResponseBuilder::new(StatusCode::OK).json(response))
+}
+
+async fn discovery() -> impl Responder {
+    HttpResponse::Ok()
+        .json(DiscoveryResponse { needs_credentials: false, client_type: ClientType::Operator })
+}
+
+async fn post_graphql(
+    req: HttpRequest,
+    payload: web::Payload,
+    schema: Data<GraphqlSchema>,
+    context: Data<RwLock<Option<GraphContext>>>,
+    ctx: Data<Context>,
+) -> Result<HttpResponse, Error> {
+    info!(ctx.expect_logger(), "{} {}", req.method().as_str(), req.path());
+    let context = context.write().await;
+    let Some(context) = context.as_ref() else {
+        return Err(ErrorRequestTimeout("Not ready"));
+    };
+    graphql_handler(&schema, &context, req, payload).await
+}
+
+async fn get_graphql(
+    req: HttpRequest,
+    payload: web::Payload,
+    schema: Data<GraphqlSchema>,
+    context: Data<RwLock<Option<GraphContext>>>,
+    ctx: Data<Context>,
+) -> Result<HttpResponse, Error> {
+    info!(ctx.expect_logger(), "{} {}", req.method().as_str(), req.path());
+    let context = context.read().await;
+    let Some(context) = context.as_ref() else {
+        return Err(ErrorRequestTimeout("Not ready"));
+    };
+    graphql_handler(&schema, &context, req, payload).await
+}
+
+async fn subscriptions(
+    req: HttpRequest,
+    stream: web::Payload,
+    schema: Data<GraphqlSchema>,
+    context: Data<RwLock<Option<GraphContext>>>,
+    ctx: Data<Context>,
+) -> Result<HttpResponse, Error> {
+    info!(ctx.expect_logger(), "{} {}", req.method().as_str(), req.path());
+    let context = context.read().await;
+    let Some(context) = context.as_ref() else {
+        return Err(ErrorRequestTimeout("Not ready"));
+    };
+    let ctx = GraphContext {
+        protocol_name: context.protocol_name.clone(),
+        runbook_name: context.runbook_name.clone(),
+        registered_addons: context.registered_addons.clone(),
+        runbook_description: context.runbook_description.clone(),
+        block_store: context.block_store.clone(),
+        block_broadcaster: context.block_broadcaster.clone(),
+        action_item_events_tx: context.action_item_events_tx.clone(),
+    };
+    let config = ConnectionConfig::new(ctx);
+    let config = config.with_keep_alive_interval(Duration::from_secs(15));
+    subscriptions::ws_handler(req, stream, schema.into_inner(), config).await
+}
+
+// async fn ws_handler(
+//     connection_params: HashMap<String, InputValue<DefaultScalarValue>>,
+//     store: Data<ExecutionStore>,
+// ) -> Result<ConnectionConfig<GraphContext>, Error> {
+//     let Some(InputValue::Object(headers)) = connection_params.get("headers") else {
+//         return Err(ErrorBadRequest("invalid auth"));
+//     };
+
+//     let Some((_, auth_header_value)) = headers
+//         .iter()
+//         .find(|(header_key, _)| header_key.item.eq("authorization"))
+//     else {
+//         return Err(ErrorBadRequest("invalid auth"));
+//     };
+
+//     let InputValue::Scalar(DefaultScalarValue::String(bearer_token_str)) =
+//         auth_header_value.item.clone()
+//     else {
+//         return Err(ErrorBadRequest("invalid auth"));
+//     };
+
+//     let bearer_token_header =
+//         HeaderValue::from_str(&bearer_token_str).map_err(|_| ErrorBadRequest("invalid auth"))?;
+
+//     let bearer_token = authorization::Bearer::parse(&bearer_token_header)
+//         .map_err(|_| ErrorBadRequest("invalid auth"))?;
+
+//     if let Some(execution) = store.find_by_auth_token(bearer_token.token()) {
+//         return Ok(ConnectionConfig::new(execution.graph_context)
+//             .with_keep_alive_interval(Duration::from_secs(15)));
+//     } else {
+//         return Err(ErrorBadRequest("invalid auth"));
+//     }
+// }

--- a/crates/txtx-cli/src/web_ui/cloud_relayer.rs
+++ b/crates/txtx-cli/src/web_ui/cloud_relayer.rs
@@ -197,7 +197,7 @@ async fn send_delete_channel(
     Ok(())
 }
 
-fn auth_token_to_totp(token: &str) -> TOTP {
+pub fn auth_token_to_totp(token: &str) -> TOTP {
     let mut hasher = Sha256::new();
     hasher.update(token.as_bytes());
     let hashed_auth_token = hasher.finalize();

--- a/crates/txtx-core/src/lib.rs
+++ b/crates/txtx-core/src/lib.rs
@@ -614,8 +614,13 @@ pub async fn build_genesis_panel(
         );
         actions.push_sub_group(None, vec![action_request]);
     }
-    let running_context = runbook.flow_contexts.first_mut().unwrap();
-    let mut pass_result = run_signers_evaluation(
+
+    let Some(running_context) = runbook.flow_contexts.first_mut() else {
+        return Err(vec![diagnosed_error!(
+            "runbook empty"
+        )])
+    };
+    let mut pass_result: eval::EvaluationPassResult = run_signers_evaluation(
         &running_context.workspace_context,
         &mut running_context.execution_context,
         &runbook.runtime_context,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new `Serve` command to start a Txtx server.
	- Implemented server functionality with GraphQL and WebSocket support.
	- Introduced routes for runbook registration and execution.

- **Improvements**
	- Enhanced error handling in server implementation.
	- Improved function visibility for authentication token processing.
	- Made the `expected_address` parameter optional in the EVM web wallet signer.

- **Experimental**
	- Server command marked as experimental with a warning message.

- **Bug Fixes**
	- Removed deprecated network addon functions and imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->