### PR TITLE
update url to the id service for logging in

### DIFF
--- a/crates/txtx-cli/src/cli/cloud/login.rs
+++ b/crates/txtx-cli/src/cli/cloud/login.rs
@@ -91,7 +91,7 @@ async fn id_service_login() -> Result<Option<LoginCallbackResult>, String> {
     let redirect_url = format!("127.0.0.1:{AUTH_CALLBACK_PORT}");
 
     let auth_service_url = reqwest::Url::parse(&format!(
-        "{}/login?callbackUrl=http://{}/api/v1/auth",
+        "{}?callbackUrl=http://{}/api/v1/auth",
         AUTH_SERVICE_URL, redirect_url
     ))
     .map_err(|e| format!("Invalid auth service URL: {e}"))?;


### PR DESCRIPTION
The login view for the id service is about to be changed (https://github.com/txtx/id.txtx.run/pull/23). This PR updated the endpoint used for accessing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved URL formatting for authentication service callback to ensure correct parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->