### PR TITLE
Svm types/subgraph event revamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14307,7 +14307,7 @@ dependencies = [
 
 [[package]]
 name = "txtx-addon-network-svm"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "async-recursion",
  "bincode",
@@ -14330,7 +14330,7 @@ dependencies = [
 
 [[package]]
 name = "txtx-addon-network-svm-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anchor-lang-idl",
  "lazy_static",

--- a/addons/svm/core/Cargo.toml
+++ b/addons/svm/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "txtx-addon-network-svm"
 description = "Primitives for executing Solana runbooks"
-version = "0.1.11"
+version = "0.1.12"
 edition = { workspace = true }
 license = "Apache-2.0"
 repository = { workspace = true }

--- a/addons/svm/core/src/templates/mod.rs
+++ b/addons/svm/core/src/templates/mod.rs
@@ -96,7 +96,6 @@ pub fn get_interpolated_anchor_subgraph_template(
             format!(
                 r#"
 action "{program_name}_{event_slug}" "svm::deploy_subgraph" {{
-    description = "A subgraph of {} occurrences in the '{program_name}' program"
     program_id = action.deploy_{program_name}.program_id
     program_idl = action.deploy_{program_name}.program_idl
     block_height = 0 // action.deploy_{program_name}.block_height
@@ -104,7 +103,7 @@ action "{program_name}_{event_slug}" "svm::deploy_subgraph" {{
         name = "{}"
     }}
 }}"#,
-                event.name, event.name
+                event.name,
             )
         })
         .collect::<Vec<_>>()

--- a/addons/svm/types/Cargo.toml
+++ b/addons/svm/types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "txtx-addon-network-svm-types"
 description = "Types for executing Solana runbooks"
-version = "0.1.0"
+version = "0.1.1"
 edition = { workspace = true }
 license = "Apache-2.0"
 repository = { workspace = true }

--- a/addons/svm/types/src/lib.rs
+++ b/addons/svm/types/src/lib.rs
@@ -43,6 +43,9 @@ pub const SVM_CLOSE_TEMP_AUTHORITY_TRANSACTION_PARTS: &str =
 pub const SVM_PAYER_SIGNED_TRANSACTION: &str = "svm::payer_signed_transaction";
 pub const SVM_AUTHORITY_SIGNED_TRANSACTION: &str = "svm::authority_signed_transaction";
 pub const SVM_TEMP_AUTHORITY_SIGNED_TRANSACTION: &str = "svm::temp_authority_signed_transaction";
+pub const SVM_U128: &str = "svm::u128";
+pub const SVM_U256: &str = "svm::u256";
+pub const SVM_I256: &str = "svm::i256";
 
 pub struct SvmValue {}
 
@@ -67,6 +70,18 @@ impl SvmValue {
 
     pub fn bytes32(bytes: Vec<u8>) -> Value {
         Value::addon(bytes, SVM_BYTES32)
+    }
+
+    pub fn u128(bytes: Vec<u8>) -> Value {
+        Value::addon(bytes, SVM_U128)
+    }
+
+    pub fn u256(bytes: Vec<u8>) -> Value {
+        Value::addon(bytes, SVM_U256)
+    }
+
+    pub fn i256(bytes: Vec<u8>) -> Value {
+        Value::addon(bytes, SVM_I256)
     }
 
     pub fn transaction_from_bytes(bytes: Vec<u8>) -> Value {

--- a/addons/svm/types/src/subgraph.rs
+++ b/addons/svm/types/src/subgraph.rs
@@ -31,7 +31,7 @@ pub fn get_expected_field_type_from_idl_type_def_ty(
                         .iter()
                         .find(|f| f.name == field_name)
                         .ok_or(format!("unable to find field '{}' in struct", field_name))?,
-                    IdlDefinedFields::Tuple(..) => {
+                    IdlDefinedFields::Tuple(_) => {
                         return Err("cannot find field by name for tuple type".to_string())
                     }
                 };

--- a/addons/svm/types/src/subgraph.rs
+++ b/addons/svm/types/src/subgraph.rs
@@ -13,7 +13,7 @@ use txtx_addon_kit::{
     },
 };
 
-use crate::SVM_PUBKEY;
+use crate::{SVM_I256, SVM_PUBKEY, SVM_U128, SVM_U256};
 
 // Subgraph keys
 pub const SVM_SUBGRAPH_REQUEST: &str = "svm::subgraph_request";
@@ -66,9 +66,9 @@ pub fn idl_type_to_txtx_type(idl_type: IdlType) -> Type {
         IdlType::I128 => Type::integer(),
         IdlType::F32 => Type::float(),
         IdlType::F64 => Type::float(),
-        IdlType::U128 => todo!(),
-        IdlType::U256 => todo!(),
-        IdlType::I256 => todo!(),
+        IdlType::U128 => Type::addon(SVM_U128),
+        IdlType::U256 => Type::addon(SVM_U256),
+        IdlType::I256 => Type::addon(SVM_I256),
         IdlType::Bytes => Type::buffer(),
         IdlType::String => Type::string(),
         IdlType::Pubkey => Type::addon(SVM_PUBKEY),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Expanded deployment capabilities with enhanced metadata for subgraph requests, including new fields for program ID and block height.
  - Added support for additional numeric types (u128, u256, i256) in value handling.
  - Introduced new structures and methods for improved event parsing and handling.

- **Refactor**
  - Streamlined request processing and event handling in subgraph deployments, including improved parameter management and error messaging.
  - Adjusted action template outputs for clearer and more concise messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->