### PR TITLE
fix: improve command descriptions for clarity

### DIFF
--- a/crates/txtx-cli/src/cli/mod.rs
+++ b/crates/txtx-cli/src/cli/mod.rs
@@ -60,32 +60,32 @@ struct Opts {
 
 #[derive(Subcommand, PartialEq, Clone, Debug)]
 enum Command {
-    /// List runbooks present in the current direcoty
+    /// List runbooks in the current directory
     #[clap(name = "ls", bin_name = "ls")]
     List(ListRunbooks),
-    /// Create a new Runbook
+    /// Create a new runbook
     #[clap(name = "new", bin_name = "new")]
     New(CreateRunbook),
-    /// Check the executability of a runbook
+    /// Check if a runbook can be executed
     #[clap(name = "check", bin_name = "check")]
     Check(CheckRunbook),
-    /// Run, runbook, run!
+    /// Execute a runbook
     #[clap(name = "run", bin_name = "run")]
     Run(ExecuteRunbook),
-    /// Display Documentation
+    /// Display documentation
     #[clap(name = "docs", bin_name = "docs")]
     Docs(GetDocumentation),
-    /// Start Txtx Language Server
+    /// Start the txtx language server
     #[clap(name = "lsp", bin_name = "lsp")]
     Lsp,
-    /// Start Txtx Server
+    /// Start the txtx server
     #[clap(name = "serve", bin_name = "serve")]
     #[cfg(feature = "txtx_serve")]
     Serve(StartServer),
     /// Snapshot management (work in progress)
     #[clap(subcommand)]
     Snapshots(SnapshotCommand),
-    /// Txtx cloud commands
+    /// txtx cloud commands
     #[clap(subcommand, name = "cloud", bin_name = "cloud")]
     Cloud(CloudCommand),
 }


### PR DESCRIPTION
This pull request makes improvements to the clarity and consistency of command descriptions in the `Command` enum within the `cli` module. The changes primarily focus on refining phrasing, correcting capitalization, and ensuring uniformity across all command descriptions.

### Improvements to command descriptions:

* Updated descriptions for commands like `List`, `New`, `Check`, `Run`, `Docs`, `Lsp`, `Serve`, and `Cloud` to use clearer and more consistent language. For example, "List runbooks present in the current direcoty" was corrected to "List runbooks in the current directory," and "Run, runbook, run!" was changed to "Execute a runbook."