### PR TITLE
fix(svm): allow processing instructions with raw instruction data

### DIFF
--- a/addons/svm/core/src/codec/instruction.rs
+++ b/addons/svm/core/src/codec/instruction.rs
@@ -132,8 +132,8 @@ pub fn parse_instructions_map(values: &ValueStore) -> Result<Vec<Instruction>, D
                         .map_err(|e| diagnosed_error!("invalid 'account' for instruction: {e}"))?;
                 let is_writable =
                     item_obj.get("is_writable").and_then(|v| v.as_bool()).unwrap_or(false);
-                    let is_signer =
-                        item_obj.get("is_signer").unwrap_or(&Value::Bool(false)).as_bool().unwrap();
+                let is_signer =
+                    item_obj.get("is_signer").and_then(|v| v.as_bool()).unwrap_or(false);
 
                     let account_meta = AccountMeta { pubkey: public_key, is_signer, is_writable };
                     accounts.push(account_meta);


### PR DESCRIPTION
I found that calling a contract without an IDL, as shown in the example, by adding data to the instruction doesn't work. It still prompts: 'program_idl' is required for each instruction. After reading the code, I found there is a RAW_BYTES method, but this approach is not simple. I need a method for testing where account and instruction data are separated and then combined. So, I made modifications based on this idea. The usage is as follows:
```
action "call" "svm::process_instructions" {
	signers = [signer.deployer]
    instruction {
        program_id = "E4Ewh6dst6ZDW1jPpMCSbvTCTwYapuUyTQaFj3vQGgUY"
        raw_data ="0x0c05000000000000"
        account {
            public_key = signer.deployer.address
            is_writable = true
            is_signer = true
        }
        account  {
            public_key = "Andy1111111111111111111111111111111111111111"
            is_writable = true
        }
        account {
            public_key = svm::system_program_id()
        }
    }
}
```