### PR TITLE
refactor(cli): improve `txtx ls` display

### DIFF
--- a/crates/txtx-cli/src/cli/runbooks/mod.rs
+++ b/crates/txtx-cli/src/cli/runbooks/mod.rs
@@ -393,20 +393,15 @@ pub async fn handle_list_command(cmd: &ListRunbooks, _ctx: &Context) -> Result<(
     }
     println!("{:<35}\t{}", "Name", yellow!("Description"));
     for runbook in manifest.runbooks {
-        println!(
-            "{:<35}\t{}",
-            runbook.name,
-            yellow!(format!(
-                "{}",
-                runbook
-                    .description
-                    .unwrap_or("".into())
-                    .split("\n")
-                    .collect::<Vec<_>>()
-                    .first()
-                    .unwrap()
-            ))
-        );
+        let heading = runbook
+            .description
+            .as_deref()
+            .unwrap_or("")
+            .lines()
+            .find(|line| !line.trim().is_empty())
+            .unwrap_or("");
+
+        println!("{:<35}\t{}", runbook.name, yellow!(heading));
     }
     Ok(())
 }


### PR DESCRIPTION
Replace complex string manipulation to:
- use idiomatic Rust patterns (as_deref, lines, find)
- handle multi-line descriptions by finding first non-empty line
- eliminate unnecessary allocations (split/collect/Vec)
- handle edge cases more gracefully (empty descriptions, whitespace-only lines)
- handle cross-platform compatibility with lines() iterator handling \n, \r\n, and \r line endings