### PR TITLE
refactor: replace solana-sdk with more granular crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,34 +1332,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
-name = "ark-bn254"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a22f4561524cd949590d78d7d4c5df8f592430d221f7f3c9497bbafd8972120f"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-std 0.4.0",
-]
-
-[[package]]
-name = "ark-ec"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
- "itertools 0.10.5",
- "num-traits",
- "zeroize",
-]
-
-[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1443,19 +1415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-poly"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d320bfc44ee185d899ccbadfa8bc31aab923ce1558716e1997a1e74057fe86bf"
-dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "derivative",
- "hashbrown 0.13.2",
-]
-
-[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1471,21 +1430,9 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive",
  "ark-std 0.4.0",
  "digest 0.10.7",
  "num-bigint 0.4.6",
-]
-
-[[package]]
-name = "ark-serialize-derive"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae3281bc6d0fd7e549af32b52511e1302185bd688fd3359fa36423346ff682ea"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -4205,18 +4152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-dalek-bip32"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d2be62a4061b872c8c0873ee4fc6f101ce7b889d039f019c5fa2af471a59908"
-dependencies = [
- "derivation-path",
- "ed25519-dalek 1.0.1",
- "hmac 0.12.1",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4318,19 +4253,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
-dependencies = [
- "atty",
- "humantime",
- "log 0.4.27",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -5891,12 +5813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
-name = "humantime"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
-
-[[package]]
 name = "hyper"
 version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6898,14 +6814,12 @@ dependencies = [
  "arrayref",
  "base64 0.12.3",
  "digest 0.9.0",
- "hmac-drbg 0.3.0",
  "libsecp256k1-core 0.2.2",
  "libsecp256k1-gen-ecmult 0.2.1",
  "libsecp256k1-gen-genmult 0.2.1",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.9",
- "typenum",
 ]
 
 [[package]]
@@ -7184,15 +7098,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
  "rustix 0.38.37",
-]
-
-[[package]]
-name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -10355,16 +10260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10412,12 +10307,6 @@ dependencies = [
  "thiserror 1.0.69",
  "time",
 ]
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "size"
@@ -10654,21 +10543,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-bn254"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9abc69625158faaab02347370b91c0d8e0fe347bf9287239f0fbe8f5864d91da"
-dependencies = [
- "ark-bn254",
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "bytemuck",
- "solana-define-syscall",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "solana-borsh"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10764,8 +10638,6 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ace9fea2daa28354d107ea879cff107181d85cd4e0f78a2bedb10e1a428c97e"
 dependencies = [
- "serde",
- "serde_derive",
  "solana-hash",
 ]
 
@@ -10777,19 +10649,6 @@ checksum = "ac49c4dde3edfa832de1697e9bcdb7c3b3f7cb7a1981b7c62526c8bb6700fb73"
 dependencies = [
  "serde",
  "serde_derive",
-]
-
-[[package]]
-name = "solana-compute-budget-interface"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a5df17b195d312b66dccdde9beec6709766d8230cb4718c4c08854f780d0309"
-dependencies = [
- "borsh 1.5.6",
- "serde",
- "serde_derive",
- "solana-instruction",
- "solana-sdk-ids",
 ]
 
 [[package]]
@@ -10871,21 +10730,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-ed25519-program"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0c4dfce08d71d8f1e9b7d1b4e2c7101a8109903ad481acbbc1119a73d459f2"
-dependencies = [
- "bytemuck",
- "bytemuck_derive",
- "ed25519-dalek 1.0.1",
- "solana-feature-set",
- "solana-instruction",
- "solana-precompile-error",
- "solana-sdk-ids",
-]
-
-[[package]]
 name = "solana-epoch-info"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10907,17 +10751,6 @@ dependencies = [
  "solana-sdk-ids",
  "solana-sdk-macro",
  "solana-sysvar-id",
-]
-
-[[package]]
-name = "solana-epoch-rewards-hasher"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c5fd2662ae7574810904585fd443545ed2b568dbd304b25a31e79ccc76e81b"
-dependencies = [
- "siphasher",
- "solana-hash",
- "solana-pubkey",
 ]
 
 [[package]]
@@ -10999,59 +10832,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-fee-structure"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f45f94a88efdb512805563181dfa1c85c60a21b6e6d602bf24a2ea88f9399d6e"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-message",
- "solana-native-token",
-]
-
-[[package]]
-name = "solana-genesis-config"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "968dabd2b92d57131473eddbd475339da530e14f54397386abf303de3a2595a2"
-dependencies = [
- "bincode",
- "chrono",
- "memmap2",
- "serde",
- "serde_derive",
- "solana-account",
- "solana-clock",
- "solana-cluster-type",
- "solana-epoch-schedule",
- "solana-fee-calculator",
- "solana-hash",
- "solana-inflation",
- "solana-keypair",
- "solana-logger",
- "solana-native-token",
- "solana-poh-config",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
- "solana-sha256-hasher",
- "solana-shred-version",
- "solana-signer",
- "solana-time-utils",
-]
-
-[[package]]
-name = "solana-hard-forks"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c28371f878e2ead55611d8ba1b5fb879847156d04edea13693700ad1a28baf"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "solana-hash"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11095,10 +10875,6 @@ name = "solana-inflation"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23eef6a09eb8e568ce6839573e4966850e85e9ce71e6ae1a6c930c1c43947de3"
-dependencies = [
- "serde",
- "serde_derive",
-]
 
 [[package]]
 name = "solana-inline-spl"
@@ -11165,11 +10941,8 @@ checksum = "3dbb7042c2e0c561afa07242b2099d55c57bd1b1da3b6476932197d84e15e3e4"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek 1.0.1",
- "ed25519-dalek-bip32",
  "rand 0.7.3",
- "solana-derivation-path",
  "solana-pubkey",
- "solana-seed-derivable",
  "solana-seed-phrase",
  "solana-signature",
  "solana-signer",
@@ -11219,6 +10992,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-loader-v3-interface"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f7162a05b8b0773156b443bccd674ea78bb9aa406325b467ea78c06c99a63a2"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-system-interface",
+]
+
+[[package]]
 name = "solana-loader-v4-interface"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11231,19 +11019,6 @@ dependencies = [
  "solana-pubkey",
  "solana-sdk-ids",
  "solana-system-interface",
-]
-
-[[package]]
-name = "solana-logger"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8e777ec1afd733939b532a42492d888ec7c88d8b4127a5d867eb45c6eb5cd5"
-dependencies = [
- "env_logger",
- "lazy_static",
- "libc",
- "log 0.4.27",
- "signal-hook",
 ]
 
 [[package]]
@@ -11345,34 +11120,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-nonce-account"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cde971a20b8dbf60144d6a84439dda86b5466e00e2843091fe731083cda614da"
-dependencies = [
- "solana-account",
- "solana-hash",
- "solana-nonce",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-offchain-message"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b526398ade5dea37f1f147ce55dae49aa017a5d7326606359b0445ca8d946581"
-dependencies = [
- "num_enum 0.7.3",
- "solana-hash",
- "solana-packet",
- "solana-pubkey",
- "solana-sanitize",
- "solana-sha256-hasher",
- "solana-signature",
- "solana-signer",
-]
-
-[[package]]
 name = "solana-packet"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11416,54 +11163,6 @@ dependencies = [
  "solana-short-vec",
  "solana-signature",
  "solana-time-utils",
-]
-
-[[package]]
-name = "solana-poh-config"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d650c3b4b9060082ac6b0efbbb66865089c58405bfb45de449f3f2b91eccee75"
-dependencies = [
- "serde",
- "serde_derive",
-]
-
-[[package]]
-name = "solana-precompile-error"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff64daa2933c22982b323d88d0cdf693201ef56ac381ae16737fd5f579e07d6"
-dependencies = [
- "num-traits",
- "solana-decode-error",
-]
-
-[[package]]
-name = "solana-precompiles"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a460ab805ec063802105b463ecb5eb02c3ffe469e67a967eea8a6e778e0bc06"
-dependencies = [
- "lazy_static",
- "solana-ed25519-program",
- "solana-feature-set",
- "solana-message",
- "solana-precompile-error",
- "solana-pubkey",
- "solana-sdk-ids",
- "solana-secp256k1-program",
- "solana-secp256r1-program",
-]
-
-[[package]]
-name = "solana-presigner"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81a57a24e6a4125fc69510b6774cd93402b943191b6cddad05de7281491c90fe"
-dependencies = [
- "solana-pubkey",
- "solana-signature",
- "solana-signer",
 ]
 
 [[package]]
@@ -11513,7 +11212,7 @@ dependencies = [
  "solana-keccak-hasher",
  "solana-last-restart-slot",
  "solana-loader-v2-interface",
- "solana-loader-v3-interface",
+ "solana-loader-v3-interface 3.0.0",
  "solana-loader-v4-interface",
  "solana-message",
  "solana-msg",
@@ -11615,7 +11314,6 @@ dependencies = [
  "getrandom 0.2.15",
  "js-sys",
  "num-traits",
- "rand 0.8.5",
  "serde",
  "serde_derive",
  "solana-atomic-u64",
@@ -11728,37 +11426,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-rent-collector"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1e19f5d5108b0d824244425e43bc78bbb9476e2199e979b0230c9f632d3bf4"
-dependencies = [
- "serde",
- "serde_derive",
- "solana-account",
- "solana-clock",
- "solana-epoch-schedule",
- "solana-genesis-config",
- "solana-pubkey",
- "solana-rent",
- "solana-sdk-ids",
-]
-
-[[package]]
-name = "solana-rent-debits"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f6f9113c6003492e74438d1288e30cffa8ccfdc2ef7b49b9e816d8034da18cd"
-dependencies = [
- "solana-pubkey",
- "solana-reward-info",
-]
-
-[[package]]
 name = "solana-reserved-account-keys"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b293f4246626c0e0a991531f08848a713ada965612e99dc510963f04d12cae7"
+checksum = "e4b22ea19ca2a3f28af7cd047c914abf833486bf7a7c4a10fc652fff09b385b1"
 dependencies = [
  "lazy_static",
  "solana-feature-set",
@@ -11869,77 +11540,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61f1bc1357b8188d9c4a3af3fc55276e56987265eb7ad073ae6f8180ee54cecf"
 
 [[package]]
-name = "solana-sdk"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4808e8d7f3c931657e615042d4176b423e66f64dc99e3dc3c735a197e512029b"
-dependencies = [
- "bincode",
- "bs58 0.5.1",
- "getrandom 0.1.16",
- "js-sys",
- "serde",
- "serde_json",
- "solana-account",
- "solana-bn254",
- "solana-client-traits",
- "solana-cluster-type",
- "solana-commitment-config",
- "solana-compute-budget-interface",
- "solana-decode-error",
- "solana-derivation-path",
- "solana-ed25519-program",
- "solana-epoch-info",
- "solana-epoch-rewards-hasher",
- "solana-feature-set",
- "solana-fee-structure",
- "solana-genesis-config",
- "solana-hard-forks",
- "solana-inflation",
- "solana-instruction",
- "solana-keypair",
- "solana-message",
- "solana-native-token",
- "solana-nonce-account",
- "solana-offchain-message",
- "solana-packet",
- "solana-poh-config",
- "solana-precompile-error",
- "solana-precompiles",
- "solana-presigner",
- "solana-program",
- "solana-program-memory",
- "solana-pubkey",
- "solana-quic-definitions",
- "solana-rent-collector",
- "solana-rent-debits",
- "solana-reserved-account-keys",
- "solana-reward-info",
- "solana-sanitize",
- "solana-sdk-ids",
- "solana-sdk-macro",
- "solana-secp256k1-program",
- "solana-secp256k1-recover",
- "solana-secp256r1-program",
- "solana-seed-derivable",
- "solana-seed-phrase",
- "solana-serde",
- "solana-serde-varint",
- "solana-short-vec",
- "solana-shred-version",
- "solana-signature",
- "solana-signer",
- "solana-system-transaction",
- "solana-time-utils",
- "solana-transaction",
- "solana-transaction-context",
- "solana-transaction-error",
- "solana-validator-exit",
- "thiserror 2.0.12",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "solana-sdk-ids"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11961,47 +11561,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-secp256k1-program"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a1caa972414cc78122c32bdae65ac5fe89df7db598585a5cde19d16a20280a"
-dependencies = [
- "bincode",
- "digest 0.10.7",
- "libsecp256k1 0.6.0",
- "serde",
- "serde_derive",
- "sha3",
- "solana-feature-set",
- "solana-instruction",
- "solana-precompile-error",
- "solana-sdk-ids",
-]
-
-[[package]]
 name = "solana-secp256k1-recover"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baa3120b6cdaa270f39444f5093a90a7b03d296d362878f7a6991d6de3bbe496"
 dependencies = [
- "borsh 1.5.6",
  "libsecp256k1 0.6.0",
  "solana-define-syscall",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "solana-secp256r1-program"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ea9282950921611bd9e0200da7236fbb1d4f8388942f8451bd55e9f3cb228f"
-dependencies = [
- "bytemuck",
- "openssl",
- "solana-feature-set",
- "solana-instruction",
- "solana-precompile-error",
- "solana-sdk-ids",
 ]
 
 [[package]]
@@ -12080,17 +11647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-shred-version"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd3db0461089d1ad1a78d9ba3f15b563899ca2386351d38428faa5350c60a98"
-dependencies = [
- "solana-hard-forks",
- "solana-hash",
- "solana-sha256-hasher",
-]
-
-[[package]]
 name = "solana-signature"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12098,7 +11654,6 @@ checksum = "47d251c8f3dc015f320b4161daac7f108156c837428e5a8cc61136d25beb11d6"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek 1.0.1",
- "rand 0.8.5",
  "serde",
  "serde-big-array",
  "serde_derive",
@@ -12234,21 +11789,6 @@ dependencies = [
  "solana-instruction",
  "solana-pubkey",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "solana-system-transaction"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd98a25e5bcba8b6be8bcbb7b84b24c2a6a8178d7fb0e3077a916855ceba91a"
-dependencies = [
- "solana-hash",
- "solana-keypair",
- "solana-message",
- "solana-pubkey",
- "solana-signer",
- "solana-system-interface",
- "solana-transaction",
 ]
 
 [[package]]
@@ -12390,12 +11930,10 @@ dependencies = [
  "serde",
  "serde_derive",
  "solana-bincode",
- "solana-feature-set",
  "solana-hash",
  "solana-instruction",
  "solana-keypair",
  "solana-message",
- "solana-precompiles",
  "solana-pubkey",
  "solana-reserved-account-keys",
  "solana-sanitize",
@@ -12414,14 +11952,12 @@ version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5022de04cbba05377f68bf848c8c1322ead733f88a657bf792bb40f3257b8218"
 dependencies = [
- "bincode",
  "serde",
  "serde_derive",
  "solana-account",
  "solana-instruction",
  "solana-pubkey",
  "solana-rent",
- "solana-signature",
 ]
 
 [[package]]
@@ -12491,12 +12027,6 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
 ]
-
-[[package]]
-name = "solana-validator-exit"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbf6d7a3c0b28dd5335c52c0e9eae49d0ae489a8f324917faf0ded65a812c1d"
 
 [[package]]
 name = "solana-version"
@@ -14066,15 +13596,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "test-case"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14876,16 +14397,31 @@ dependencies = [
  "bincode",
  "borsh 0.10.4",
  "borsh 1.5.6",
+ "bs58 0.5.1",
  "convert_case 0.6.0",
  "kaigan",
  "lazy_static",
  "serde",
  "serde_derive",
  "serde_json",
+ "solana-account",
  "solana-client",
+ "solana-clock",
+ "solana-commitment-config",
+ "solana-hash",
+ "solana-instruction",
+ "solana-keypair",
+ "solana-loader-v3-interface 5.0.0",
  "solana-message",
+ "solana-native-token",
+ "solana-packet",
+ "solana-pubkey",
  "solana-record-service-client",
- "solana-sdk",
+ "solana-sdk-ids",
+ "solana-signature",
+ "solana-signer",
+ "solana-system-interface",
+ "solana-transaction",
  "solana_idl",
  "spl-associated-token-account",
  "spl-token",

--- a/addons/svm/core/Cargo.toml
+++ b/addons/svm/core/Cargo.toml
@@ -17,10 +17,25 @@ serde_json = "1.0.113"
 serde = "1"
 serde_derive = "1"
 async-recursion = "1"
+bs58 = "0.5.0"
 bincode = "1.3.3"
-solana-sdk = { version = "2.2.1", features = ["borsh"] }
 solana-message = { version = "2.2.1", features = ["serde"] }
 solana-client = "2.2.1"
+solana-clock = "2.2.1"
+solana-sdk-ids = "2.2.1"
+solana-account = "2.2.1"
+solana-keypair = "2.2.1"
+solana-pubkey = "2.2.1"
+solana-hash = "2.2.1"
+solana-transaction = { version = "2.2.1", features = ["verify"] }
+solana-signature = "2.2.1"
+solana-signer = "2.2.1"
+solana-instruction = "2.2.1"
+solana-packet = "2.2.1"
+solana-native-token = "2.2.1"
+solana-commitment-config = "2.2.1"
+solana-loader-v3-interface = { version = "5.0.0", features = ["bincode"] }
+solana-system-interface = { version = "1.0.0", features = ["bincode"] }
 spl-associated-token-account = "6.0.0"
 spl-token = "7.0.0"
 spl-token-2022 = "7.0.0"

--- a/addons/svm/core/src/codec/anchor.rs
+++ b/addons/svm/core/src/codec/anchor.rs
@@ -2,7 +2,8 @@ use std::{path::PathBuf, str::FromStr};
 
 use crate::{codec::validate_program_so, typing::anchor::types as anchor_types};
 
-use solana_sdk::{pubkey::Pubkey, signature::Keypair};
+use solana_keypair::Keypair;
+use solana_pubkey::Pubkey;
 use txtx_addon_kit::{
     indexmap::IndexMap,
     types::{

--- a/addons/svm/core/src/codec/idl/mod.rs
+++ b/addons/svm/core/src/codec/idl/mod.rs
@@ -9,7 +9,7 @@ use anchor_lang_idl::types::{
     IdlTypeDefGeneric, IdlTypeDefTy,
 };
 use convert_idl::classic_idl_to_anchor_idl;
-use solana_sdk::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 use std::fmt::Display;
 use txtx_addon_kit::types::diagnostics::Diagnostic;
 use txtx_addon_kit::{helpers::fs::FileLocation, indexmap::IndexMap, types::types::Value};

--- a/addons/svm/core/src/codec/instruction.rs
+++ b/addons/svm/core/src/codec/instruction.rs
@@ -1,9 +1,7 @@
 use std::{collections::VecDeque, str::FromStr};
 
-use solana_sdk::{
-    instruction::{AccountMeta, Instruction},
-    pubkey::Pubkey,
-};
+use solana_instruction::{AccountMeta, Instruction};
+use solana_pubkey::Pubkey;
 use txtx_addon_kit::{
     indexmap::IndexMap,
     types::{diagnostics::Diagnostic, stores::ValueStore, types::Value},

--- a/addons/svm/core/src/codec/mod.rs
+++ b/addons/svm/core/src/codec/mod.rs
@@ -20,27 +20,24 @@ use native::NativeProgramArtifacts;
 use serde::Deserialize;
 use serde::Serialize;
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::account_utils::StateMut;
-use solana_sdk::bpf_loader_upgradeable::create_buffer;
-use solana_sdk::bpf_loader_upgradeable::get_program_data_address;
-use solana_sdk::bpf_loader_upgradeable::UpgradeableLoaderState;
-use solana_sdk::commitment_config::CommitmentConfig;
-use solana_sdk::commitment_config::CommitmentLevel;
-use solana_sdk::hash::Hash;
-use solana_sdk::packet::PACKET_DATA_SIZE;
-use solana_sdk::signature::keypair_from_seed;
-use solana_sdk::signature::Keypair;
-use solana_sdk::signature::Signature;
-use solana_sdk::signer::Signer;
-use solana_sdk::system_instruction;
-use solana_sdk::system_instruction::MAX_PERMITTED_DATA_LENGTH;
+use solana_account::state_traits::StateMut;
+use solana_loader_v3_interface::{get_program_data_address, instruction::create_buffer, state::UpgradeableLoaderState};
+use solana_commitment_config::CommitmentConfig;
+use solana_commitment_config::CommitmentLevel;
+use solana_hash::Hash;
+use solana_packet::PACKET_DATA_SIZE;
+use solana_keypair::{Keypair, keypair_from_seed};
+use solana_signature::Signature;
+use solana_signer::Signer;
+use solana_system_interface::instruction as system_instruction;
+use solana_system_interface::MAX_PERMITTED_DATA_LENGTH;
 use txtx_addon_kit::types::frontend::LogDispatcher;
-// use solana_sdk::loader_v4::finalize;
 use crate::typing::DeploymentTransactionType;
-use solana_sdk::{
-    bpf_loader_upgradeable, instruction::Instruction, message::Message, pubkey::Pubkey,
-    transaction::Transaction,
-};
+use solana_loader_v3_interface::instruction as bpf_loader_upgradeable;
+use solana_instruction::Instruction;
+use solana_message::Message;
+use solana_pubkey::Pubkey;
+use solana_transaction::Transaction;
 use std::collections::HashMap;
 use std::str::FromStr;
 use txtx_addon_kit::types::diagnostics::Diagnostic;
@@ -766,7 +763,7 @@ impl UpgradeableProgramDeployer {
                     )
                 })?;
 
-                if buffer_account.owner != bpf_loader_upgradeable::id() {
+                if buffer_account.owner != solana_sdk_ids::bpf_loader_upgradeable::id() {
                     return Err(diagnosed_error!(
                         "buffer account {} is not owned by the bpf_loader_upgradeable program",
                         buffer_pubkey
@@ -1055,7 +1052,7 @@ impl UpgradeableProgramDeployer {
                         &self.temp_upgrade_authority_pubkey,
                         lamports,
                         0,
-                        &solana_sdk::system_program::id(),
+                        &solana_sdk_ids::system_program::id(),
                     ),
                     vec![&self.temp_upgrade_authority],
                 )
@@ -1500,7 +1497,7 @@ impl UpgradeableProgramDeployer {
             .map_err(|e| diagnosed_error!("failed to get program account: {e}"))?
             .value
         {
-            if account.owner != bpf_loader_upgradeable::id() {
+            if account.owner != solana_sdk_ids::bpf_loader_upgradeable::id() {
                 return Err(diagnosed_error!(
                     "Account {} is not an upgradeable program or already is in use",
                     program_pubkey

--- a/addons/svm/core/src/codec/native.rs
+++ b/addons/svm/core/src/codec/native.rs
@@ -1,7 +1,9 @@
 use std::str::FromStr;
 
 use crate::{codec::validate_program_so, typing::anchor::types as anchor_types};
-use solana_sdk::{pubkey::Pubkey, signature::Keypair, signer::Signer};
+use solana_keypair::Keypair;
+use solana_pubkey::Pubkey;
+use solana_signer::Signer;
 use txtx_addon_kit::{
     helpers::fs::FileLocation,
     types::{

--- a/addons/svm/core/src/codec/send_transaction.rs
+++ b/addons/svm/core/src/codec/send_transaction.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 
 use solana_client::rpc_client::RpcClient;
 use solana_client::rpc_config::RpcSendTransactionConfig;
-use solana_sdk::commitment_config::{CommitmentConfig, CommitmentLevel};
-use solana_sdk::transaction::Transaction;
+use solana_commitment_config::{CommitmentConfig, CommitmentLevel};
+use solana_transaction::Transaction;
 use txtx_addon_kit::channel;
 use txtx_addon_kit::constants::SIGNED_TRANSACTION_BYTES;
 use txtx_addon_kit::types::commands::CommandExecutionResult;

--- a/addons/svm/core/src/codec/squads/compiled_keys.rs
+++ b/addons/svm/core/src/codec/squads/compiled_keys.rs
@@ -1,9 +1,9 @@
 use std::collections::BTreeMap;
 
-use solana_sdk::instruction::Instruction;
-use solana_sdk::message::v0::{LoadedAddresses, MessageAddressTableLookup};
-use solana_sdk::message::{AddressLookupTableAccount, CompileError, MessageHeader};
-use solana_sdk::pubkey::Pubkey;
+use solana_instruction::Instruction;
+use solana_message::v0::{LoadedAddresses, MessageAddressTableLookup};
+use solana_message::{AddressLookupTableAccount, CompileError, MessageHeader};
+use solana_pubkey::Pubkey;
 
 /// A helper struct to collect pubkeys compiled for a set of instructions
 ///

--- a/addons/svm/core/src/codec/squads/mod.rs
+++ b/addons/svm/core/src/codec/squads/mod.rs
@@ -4,13 +4,11 @@ use multisig::Multisig;
 use proposal::{get_proposal_ix_data, Proposal, ProposalStatus};
 use serde::{Deserialize, Serialize};
 use solana_client::rpc_client::{GetConfirmedSignaturesForAddress2Config, RpcClient};
-use solana_sdk::{
-    instruction::{AccountMeta, Instruction},
-    message::Message,
-    pubkey::Pubkey,
-    system_program,
-    transaction::Transaction,
-};
+use solana_instruction::{AccountMeta, Instruction};
+use solana_message::Message;
+use solana_pubkey::Pubkey;
+use solana_sdk_ids::system_program;
+use solana_transaction::Transaction;
 use txtx_addon_kit::types::{diagnostics::Diagnostic, types::Value, ConstructDid};
 use txtx_addon_network_svm_types::{SvmValue, SVM_SQUAD_MULTISIG};
 use vault_transaction::get_create_vault_transaction_ix_data;

--- a/addons/svm/core/src/codec/squads/multisig.rs
+++ b/addons/svm/core/src/codec/squads/multisig.rs
@@ -1,5 +1,5 @@
 use borsh::BorshDeserialize;
-use solana_sdk::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 use txtx_addon_kit::types::diagnostics::Diagnostic;
 
 use crate::codec::idl::convert_idl::compute_discriminator;

--- a/addons/svm/core/src/codec/squads/pda.rs
+++ b/addons/svm/core/src/codec/squads/pda.rs
@@ -1,6 +1,6 @@
 /// This is all copied from the Squads v4 program. I couldn't pull the crate due to dependency collisions.
 /// https://github.com/Squads-Protocol/v4
-use solana_sdk::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 use super::SQUADS_MULTISIG_PROGRAM_ID;
 

--- a/addons/svm/core/src/codec/squads/proposal.rs
+++ b/addons/svm/core/src/codec/squads/proposal.rs
@@ -1,5 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use solana_sdk::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 use txtx_addon_kit::types::diagnostics::Diagnostic;
 
 use crate::codec::idl::convert_idl::compute_discriminator;

--- a/addons/svm/core/src/codec/squads/vault_transaction.rs
+++ b/addons/svm/core/src/codec/squads/vault_transaction.rs
@@ -1,9 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use solana_sdk::{
-    instruction::{AccountMeta, Instruction},
-    message::{AccountKeys, AddressLookupTableAccount, Message},
-    pubkey::Pubkey,
-};
+use solana_instruction::{AccountMeta, Instruction};
+use solana_message::{AccountKeys, AddressLookupTableAccount, Message};
+use solana_pubkey::Pubkey;
 use txtx_addon_kit::types::diagnostics::Diagnostic;
 
 use super::{compiled_keys::CompiledKeys, small_vec::SmallVec};

--- a/addons/svm/core/src/codec/ui_encode.rs
+++ b/addons/svm/core/src/codec/ui_encode.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use solana_message::Message;
-use solana_sdk::instruction::Instruction;
+use solana_instruction::Instruction;
 use txtx_addon_kit::{
     hex,
     types::{

--- a/addons/svm/core/src/codec/utils.rs
+++ b/addons/svm/core/src/codec/utils.rs
@@ -1,11 +1,10 @@
 use std::{str::FromStr, thread::sleep, time::Duration};
 
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    bpf_loader_upgradeable::{self, get_program_data_address, UpgradeableLoaderState},
-    clock::DEFAULT_MS_PER_SLOT,
-    pubkey::Pubkey,
-};
+use solana_clock::DEFAULT_MS_PER_SLOT;
+use solana_loader_v3_interface::{get_program_data_address, state::UpgradeableLoaderState};
+use solana_pubkey::Pubkey;
+
 use txtx_addon_kit::types::{diagnostics::Diagnostic, types::Value};
 
 use crate::commands::setup_surfnet::set_account::SurfpoolAccountUpdate;
@@ -68,7 +67,7 @@ pub async fn cheatcode_deploy_program(
         public_key: program_data_address,
         lamports: Some(rent_lamports),
         data: Some(txtx_addon_kit::hex::encode(program_data)),
-        owner: Some(bpf_loader_upgradeable::id().to_string()),
+        owner: Some(solana_sdk_ids::bpf_loader_upgradeable::id().to_string()),
         executable: Some(false),
         rent_epoch: Some(0),
     };
@@ -86,7 +85,7 @@ pub async fn cheatcode_deploy_program(
         public_key: program_id,
         lamports: Some(rent_lamports),
         data: Some(txtx_addon_kit::hex::encode(&program_data)),
-        owner: Some(bpf_loader_upgradeable::id().to_string()),
+        owner: Some(solana_sdk_ids::bpf_loader_upgradeable::id().to_string()),
         executable: Some(true),
         rent_epoch: Some(0),
     };

--- a/addons/svm/core/src/commands/deploy_program.rs
+++ b/addons/svm/core/src/commands/deploy_program.rs
@@ -3,10 +3,10 @@ use std::str::FromStr;
 use std::vec;
 
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::bs58;
-use solana_sdk::commitment_config::CommitmentConfig;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::signature::Keypair;
+use bs58;
+use solana_commitment_config::CommitmentConfig;
+use solana_pubkey::Pubkey;
+use solana_keypair::Keypair;
 use txtx_addon_kit::channel;
 use txtx_addon_kit::constants::{
     DESCRIPTION, META_DESCRIPTION, NESTED_CONSTRUCT_COUNT, NESTED_CONSTRUCT_DID,

--- a/addons/svm/core/src/commands/process_instructions.rs
+++ b/addons/svm/core/src/commands/process_instructions.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::message::Message;
-use solana_sdk::transaction::Transaction;
+use solana_message::Message;
+use solana_transaction::Transaction;
 use txtx_addon_kit::channel;
 use txtx_addon_kit::futures::future;
 use txtx_addon_kit::types::cloud_interface::CloudServiceContext;

--- a/addons/svm/core/src/commands/send_sol.rs
+++ b/addons/svm/core/src/commands/send_sol.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::message::Message;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::transaction::Transaction;
+use solana_message::Message;
+use solana_pubkey::Pubkey;
+use solana_transaction::Transaction;
 use txtx_addon_kit::channel;
 use txtx_addon_kit::futures::future;
 use txtx_addon_kit::types::cloud_interface::CloudServiceContext;
@@ -163,7 +163,7 @@ impl CommandImplementation for SendSol {
             .map_err(|e| (signers.clone(), signer_state.clone(), e))?;
 
         let instruction =
-            solana_sdk::system_instruction::transfer(&signer_pubkey, &recipient, amount);
+            solana_system_interface::instruction::transfer(&signer_pubkey, &recipient, amount);
 
         let mut message = Message::new(&vec![instruction], None);
         let client = RpcClient::new(rpc_api_url);

--- a/addons/svm/core/src/commands/send_token.rs
+++ b/addons/svm/core/src/commands/send_token.rs
@@ -2,9 +2,9 @@ use std::collections::{HashMap, VecDeque};
 use std::str::FromStr;
 
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::message::Message;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::transaction::Transaction;
+use solana_message::Message;
+use solana_pubkey::Pubkey;
+use solana_transaction::Transaction;
 use txtx_addon_kit::channel;
 use txtx_addon_kit::futures::future;
 use txtx_addon_kit::types::cloud_interface::CloudServiceContext;

--- a/addons/svm/core/src/commands/setup_surfnet/cheatcode_deploy_program.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/cheatcode_deploy_program.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_request::RpcRequest;
-use solana_sdk::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 use txtx_addon_kit::{
     indexmap::IndexMap,

--- a/addons/svm/core/src/commands/setup_surfnet/clone_program_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/clone_program_account.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_request::RpcRequest;
-use solana_sdk::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 use txtx_addon_kit::{
     indexmap::IndexMap,

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_request::RpcRequest;
-use solana_sdk::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 use txtx_addon_kit::{
     hex,
     indexmap::IndexMap,

--- a/addons/svm/core/src/commands/setup_surfnet/set_program_authority.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_program_authority.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_request::RpcRequest;
-use solana_sdk::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 use txtx_addon_kit::{
     indexmap::IndexMap,

--- a/addons/svm/core/src/commands/setup_surfnet/set_token_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_token_account.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_client::rpc_request::RpcRequest;
-use solana_sdk::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 use spl_associated_token_account::get_associated_token_address_with_program_id;
 
 use serde::de::Visitor;

--- a/addons/svm/core/src/commands/setup_surfnet/tokens.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/tokens.rs
@@ -1,4 +1,4 @@
-use solana_sdk::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 
 const MAINNET_AAVE_PROGRAM_ID: &str = "3vAs4D1WE6Na4tCgt4BApgFfENbm8WY7q4cSPD1yM4Cg";
 const MAINNET_AUDIO_PROGRAM_ID: &str = "9LzCMqDgTKYz9Drzqnpgee3SGa89up3a247ypMj2xrqM";

--- a/addons/svm/core/src/commands/sign_transaction.rs
+++ b/addons/svm/core/src/commands/sign_transaction.rs
@@ -4,7 +4,7 @@ use crate::commands::get_signers_did;
 use crate::constants::PREVIOUSLY_SIGNED_BLOCKHASH;
 use crate::typing::SvmValue;
 use crate::utils::build_transaction_from_svm_value;
-use solana_sdk::signature::Signature;
+use solana_signature::Signature;
 use std::collections::HashMap;
 use txtx_addon_kit::constants::META_DESCRIPTION;
 use txtx_addon_kit::constants::SIGNED_TRANSACTION_BYTES;
@@ -150,7 +150,7 @@ pub fn run_signed_execution(
             (payload, None)
         };
         let mut combined_transaction = build_transaction_from_svm_value(&payload).unwrap();
-        let mut blockhash: Option<solana_sdk::hash::Hash> = None;
+        let mut blockhash: Option<solana_hash::Hash> = None;
         let mut cursor = 0;
 
         for (signer_did, signer_instance) in signers_dids_with_instances {

--- a/addons/svm/core/src/commands/srs/create_class.rs
+++ b/addons/svm/core/src/commands/srs/create_class.rs
@@ -8,11 +8,11 @@ use solana_record_service_client::instructions::{
     CreateClassBuilder, FreezeClassBuilder, UpdateClassMetadataBuilder,
 };
 use solana_record_service_client::programs::SOLANA_RECORD_SERVICE_ID;
-use solana_sdk::commitment_config::CommitmentConfig;
-use solana_sdk::message::Message;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::system_program;
-use solana_sdk::transaction::Transaction;
+use solana_commitment_config::CommitmentConfig;
+use solana_message::Message;
+use solana_pubkey::Pubkey;
+use solana_sdk_ids::system_program;
+use solana_transaction::Transaction;
 use txtx_addon_kit::channel;
 use txtx_addon_kit::constants::META_DESCRIPTION;
 use txtx_addon_kit::types::cloud_interface::CloudServiceContext;

--- a/addons/svm/core/src/commands/srs/create_record.rs
+++ b/addons/svm/core/src/commands/srs/create_record.rs
@@ -9,11 +9,11 @@ use solana_record_service_client::instructions::{
     CreateRecordBuilder, FreezeRecordBuilder, TransferRecordBuilder, UpdateRecordBuilder,
 };
 use solana_record_service_client::programs::SOLANA_RECORD_SERVICE_ID;
-use solana_sdk::commitment_config::CommitmentConfig;
-use solana_sdk::message::Message;
-use solana_sdk::pubkey::Pubkey;
-use solana_sdk::system_program;
-use solana_sdk::transaction::Transaction;
+use solana_commitment_config::CommitmentConfig;
+use solana_message::Message;
+use solana_pubkey::Pubkey;
+use solana_sdk_ids::system_program;
+use solana_transaction::Transaction;
 use txtx_addon_kit::channel;
 use txtx_addon_kit::constants::META_DESCRIPTION;
 use txtx_addon_kit::types::cloud_interface::CloudServiceContext;

--- a/addons/svm/core/src/functions.rs
+++ b/addons/svm/core/src/functions.rs
@@ -3,7 +3,8 @@ use std::path::PathBuf;
 use crate::{codec::utils::get_seeds_from_value, typing::anchor::types::Idl};
 
 use crate::constants::{DEFAULT_NATIVE_TARGET_PATH, DEFAULT_SHANK_IDL_PATH};
-use solana_sdk::{pubkey::Pubkey, system_program};
+use solana_pubkey::Pubkey;
+use solana_sdk_ids::system_program;
 use spl_associated_token_account::instruction::create_associated_token_account_idempotent;
 use txtx_addon_kit::types::{
     diagnostics::Diagnostic,
@@ -708,7 +709,7 @@ impl FunctionImplementation for SolToLamports {
             }
             _ => unreachable!(),
         };
-        let lamports = solana_sdk::native_token::sol_to_lamports(sol);
+        let lamports = solana_native_token::sol_to_lamports(sol);
         Ok(Value::integer(lamports as i128))
     }
 }
@@ -731,7 +732,7 @@ impl FunctionImplementation for LamportsToSol {
         arg_checker(fn_spec, args)?;
         let lamports = args.get(0).unwrap().as_uint().unwrap().map_err(|e| to_diag(fn_spec, e))?;
 
-        let sol = solana_sdk::native_token::lamports_to_sol(lamports);
+        let sol = solana_native_token::lamports_to_sol(lamports);
         Ok(Value::float(sol))
     }
 }

--- a/addons/svm/core/src/lib.rs
+++ b/addons/svm/core/src/lib.rs
@@ -12,7 +12,7 @@ pub mod rpc;
 mod signers;
 pub mod templates;
 pub mod utils;
-pub use solana_sdk::pubkey::Pubkey;
+pub use solana_pubkey::Pubkey;
 
 pub mod typing {
     pub use txtx_addon_network_svm_types::*;

--- a/addons/svm/core/src/signers/mod.rs
+++ b/addons/svm/core/src/signers/mod.rs
@@ -4,7 +4,7 @@ pub mod web_wallet;
 
 use secret_key::SVM_SECRET_KEY;
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::pubkey::Pubkey;
+use solana_pubkey::Pubkey;
 use squads::SVM_SQUADS;
 use txtx_addon_kit::types::{
     diagnostics::Diagnostic,
@@ -123,7 +123,7 @@ async fn get_check_balance_action(
         Some(address) => match solana_rpc.get_balance(&address).await {
             Ok(response) => (
                 ActionItemStatus::Todo,
-                Value::float(solana_sdk::native_token::lamports_to_sol(response)),
+                Value::float(solana_native_token::lamports_to_sol(response)),
             ),
             Err(err) => (
                 ActionItemStatus::Error(diagnosed_error!(

--- a/addons/svm/core/src/signers/secret_key.rs
+++ b/addons/svm/core/src/signers/secret_key.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::commitment_config::{CommitmentConfig, CommitmentLevel};
-use solana_sdk::signature::Keypair;
-use solana_sdk::transaction::Transaction;
+use solana_commitment_config::{CommitmentConfig, CommitmentLevel};
+use solana_keypair::Keypair;
+use solana_transaction::Transaction;
 use txtx_addon_kit::channel;
 use txtx_addon_kit::constants::{SIGNATURE_APPROVED, SIGNATURE_SKIPPABLE};
 use txtx_addon_kit::types::commands::CommandExecutionResult;
@@ -135,7 +135,8 @@ impl SignerImplementation for SvmSecretKey {
             DEFAULT_DERIVATION_PATH, DERIVATION_PATH, IS_ENCRYPTED, KEYPAIR_JSON, MNEMONIC,
             PASSWORD, REQUESTED_STARTUP_DATA, SECRET_KEY,
         };
-        use solana_sdk::{signature::Keypair, signer::Signer};
+        use solana_keypair::Keypair;
+        use solana_signer::Signer;
         use txtx_addon_kit::{constants::DESCRIPTION, crypto::secret_key_bytes_from_mnemonic};
         let mut actions = Actions::none();
 
@@ -395,7 +396,7 @@ impl SignerImplementation for SvmSecretKey {
 
         // prevent discrepancies between new block hash and a hash on the transaction that's already been signed
         let blockhash = if let Some(blockhash) = &previously_signed_blockhash {
-            solana_sdk::hash::Hash::new_from_array(blockhash.to_be_bytes().try_into().unwrap())
+            solana_hash::Hash::new_from_array(blockhash.to_be_bytes().try_into().unwrap())
         } else {
             let rpc_api_url = values
                 .get_expected_string(RPC_API_URL)

--- a/addons/svm/core/src/signers/squads.rs
+++ b/addons/svm/core/src/signers/squads.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::signature::Signature;
-use solana_sdk::transaction::Transaction;
+use solana_signature::Signature;
+use solana_transaction::Transaction;
 use txtx_addon_kit::channel;
 use txtx_addon_kit::constants::{
     META_DESCRIPTION, SIGNED_TRANSACTION_BYTES, THIRD_PARTY_SIGNATURE_STATUS,

--- a/addons/svm/core/src/signers/web_wallet.rs
+++ b/addons/svm/core/src/signers/web_wallet.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 
 use solana_client::rpc_client::RpcClient;
-use solana_sdk::commitment_config::CommitmentConfig;
-use solana_sdk::signature::Signature;
-use solana_sdk::transaction::Transaction;
+use solana_commitment_config::CommitmentConfig;
+use solana_signature::Signature;
+use solana_transaction::Transaction;
 use txtx_addon_kit::channel;
 use txtx_addon_kit::constants::{SIGNATURE_SKIPPABLE, SIGNED_TRANSACTION_BYTES};
 use txtx_addon_kit::types::commands::CommandExecutionResult;

--- a/addons/svm/core/src/utils.rs
+++ b/addons/svm/core/src/utils.rs
@@ -2,7 +2,7 @@ use crate::codec::DeploymentTransaction;
 use crate::typing::{
     SVM_CLOSE_TEMP_AUTHORITY_TRANSACTION_PARTS, SVM_DEPLOYMENT_TRANSACTION, SVM_TRANSACTION,
 };
-use solana_sdk::transaction::Transaction;
+use solana_transaction::Transaction;
 use txtx_addon_kit::hex;
 use txtx_addon_kit::types::{diagnostics::Diagnostic, types::Value};
 


### PR DESCRIPTION
### Problem

`txtx-addon-network-svm` crate uses bloated `solana-sdk` dependency

### Summary of Changes

extract more granular crates `solana-xxx`

cc @MicaiahReid 