### PR TITLE
feat(svm): add patch_raw in set_account

### DIFF
--- a/addons/svm/core/src/commands/setup_surfnet/mod.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/mod.rs
@@ -218,7 +218,12 @@ impl CommandImplementation for SetupSurfpool {
             let logger =
                 LogDispatcher::new(construct_did.as_uuid(), "svm::setup_surfnet", &progress_tx);
 
-            let account_updates = SurfpoolAccountUpdate::parse_value_store(&values, &auth_context)?;
+            let acc_data =
+                SurfpoolAccountUpdate::get_accounts_data_if_needed(&values, &rpc_client).await?;
+
+            let account_updates =
+                SurfpoolAccountUpdate::parse_value_store(&values, &auth_context, acc_data)?;
+
             SurfpoolAccountUpdate::process_updates(account_updates, &rpc_client, &logger).await?;
 
             let token_account_updates = SurfpoolTokenAccountUpdate::parse_value_store(&values)?;

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -350,26 +350,29 @@ impl SurfpoolAccountUpdate {
         };
 
         let accounts_to_fetch = account_updates
-        .iter()
-        .enumerate()
-        .filter_map(|(i, update)| {
-            update.get("patch")?;
-            let prefix = format!("failed to parse `set_account` map #{}", i + 1);
-            Some(
-                update
-                    .get("public_key")
-                    .ok_or_else(|| {
-                        diagnosed_error!(
-                            "{prefix} missing required 'public_key' field and 'pubkey' field in account file"
-                        )
-                    })
-                    .and_then(|pk| {
-                        SvmValue::to_pubkey(pk)
-                            .map_err(|e| diagnosed_error!("{prefix} invalid 'public_key' field: {e}"))
-                    }),
-            )
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+            .iter()
+            .enumerate()
+            .filter_map(|(i, update)| {
+                update.get("patch")?;
+                let prefix = format!("failed to parse `set_account` map #{}", i + 1);
+                Some(
+                    update
+                        .get("public_key")
+                        .ok_or_else(|| {
+                            diagnosed_error!(
+                                "{prefix} missing required 'public_key' field and 'pubkey' field in account file"
+                            )
+                        })
+                        .and_then(|pk| {
+                            SvmValue::to_pubkey(pk).map_err(|e| {
+                                diagnosed_error!(
+                                    "{prefix} invalid 'public_key' field: {e}"
+                                )
+                            })
+                        }),
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         if accounts_to_fetch.is_empty() {
             return Ok(HashMap::new());
@@ -522,14 +525,98 @@ mod tests {
         let auth_ctx = AuthorizationContext::empty();
         let mut prefetched_data = HashMap::new();
 
-        prefetched_data.insert(
-            PUBKEY.to_string(),
-            vec![0; 8], // Original data is 8 bytes of zeros
-        );
+        prefetched_data.insert(PUBKEY.to_string(), vec![0; 8]);
         let account_update =
             SurfpoolAccountUpdate::from_map(&mut map, &auth_ctx, &prefetched_data)?;
         assert_eq!(account_update.public_key.to_string(), PUBKEY.to_string());
-        assert_eq!(account_update.data, Some("0100000000000000".to_string())); // 1 in little-endian hex
+        assert_eq!(account_update.data, Some("0100000000000000".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_apply_multiple_patches() -> Result<(), Diagnostic> {
+        let patch = Value::array(vec![
+            Value::object({
+                let mut m = IndexMap::new();
+                m.insert("offset".to_string(), Value::Integer(0));
+                m.insert("length".to_string(), Value::Integer(4));
+                m.insert("field_value".to_string(), Value::String("100".to_string()));
+                m.insert("field_type".to_string(), Value::String("u32".to_string()));
+                m
+            }),
+            Value::object({
+                let mut m = IndexMap::new();
+                m.insert("offset".to_string(), Value::Integer(4));
+                m.insert("length".to_string(), Value::Integer(4));
+                m.insert("field_value".to_string(), Value::String("200".to_string()));
+                m.insert("field_type".to_string(), Value::String("u32".to_string()));
+                m
+            }),
+            Value::object({
+                let mut m = IndexMap::new();
+                m.insert("offset".to_string(), Value::Integer(8));
+                m.insert("length".to_string(), Value::Integer(1));
+                m.insert("field_value".to_string(), Value::String("true".to_string()));
+                m.insert("field_type".to_string(), Value::String("boolean".to_string()));
+                m
+            }),
+        ]);
+
+        let data = Some(vec![0u8; 16]);
+        let prefetched = HashMap::new();
+        let pubkey = pubkey!("11111111111111111111111111111111");
+
+        let result = apply_patches(data, &patch, &prefetched, &pubkey)?;
+
+        assert_eq!(&result[0..4], &100u32.to_le_bytes());
+        assert_eq!(&result[4..8], &200u32.to_le_bytes());
+        assert_eq!(result[8], 1u8);
+        assert_eq!(&result[9..16], &[0u8; 7]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_apply_patches_uses_provided_data_over_prefetched() -> Result<(), Diagnostic> {
+        let patch = Value::array(vec![Value::object({
+            let mut m = IndexMap::new();
+            m.insert("offset".to_string(), Value::Integer(0));
+            m.insert("length".to_string(), Value::Integer(1));
+            m.insert("field_value".to_string(), Value::String("42".to_string()));
+            m.insert("field_type".to_string(), Value::String("u8".to_string()));
+            m
+        })]);
+
+        let pubkey = pubkey!("11111111111111111111111111111111");
+
+        let provided_data = Some(vec![0xFF; 4]);
+        let mut prefetched = HashMap::new();
+        prefetched.insert(pubkey.to_string(), vec![0xAA; 4]);
+
+        let result = apply_patches(provided_data, &patch, &prefetched, &pubkey)?;
+        assert_eq!(result[0], 42);
+        assert_eq!(&result[1..4], &[0xFF; 3]);
+        Ok(())
+    }
+
+    #[test]
+    fn test_apply_patches_falls_back_to_prefetched() -> Result<(), Diagnostic> {
+        let patch = Value::array(vec![Value::object({
+            let mut m = IndexMap::new();
+            m.insert("offset".to_string(), Value::Integer(0));
+            m.insert("length".to_string(), Value::Integer(1));
+            m.insert("field_value".to_string(), Value::String("42".to_string()));
+            m.insert("field_type".to_string(), Value::String("u8".to_string()));
+            m
+        })]);
+
+        let pubkey = pubkey!("11111111111111111111111111111111");
+
+        let mut prefetched = HashMap::new();
+        prefetched.insert(pubkey.to_string(), vec![0xBB; 4]);
+
+        let result = apply_patches(None, &patch, &prefetched, &pubkey)?;
+        assert_eq!(result[0], 42);
+        assert_eq!(&result[1..4], &[0xBB; 3]);
         Ok(())
     }
 }

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -55,14 +55,14 @@ fn field_value_to_bytes(field_type: &str, field_value: &Value) -> Result<Vec<u8>
         "buffer" => hex::decode(&field_value.to_string())
             .map_err(|e| diagnosed_error!("failed to parse field_value as hex string: {e}")),
         _ => Err(diagnosed_error!(
-            "invalid 'field_type' field in patch item: must be one of \
+            "invalid 'field_type' field in patch_raw item: must be one of \
             'u8', 'i8', 'u16', 'i16', 'u32', 'i32', 'u64', 'i64', \
             'u128', 'i128', 'f32', 'f64', 'pubkey', 'string', 'boolean', or 'buffer'"
         )),
     }
 }
 
-fn apply_patches(
+fn apply_patches_raw(
     data_bytes: Option<Vec<u8>>,
     patch: &Value,
     prefetched_data: &HashMap<String, Vec<u8>>,
@@ -70,7 +70,7 @@ fn apply_patches(
 ) -> Result<Vec<u8>, Diagnostic> {
     let patches = patch.as_array().ok_or_else(|| {
         diagnosed_error!(
-            "expected 'patch' field to be a map with 'offset', 'length', and 'bytes' fields"
+            "expected 'patch_raw' field to be an array of maps with 'offset', 'length', 'field_value', and 'field_type' fields"
         )
     })?;
 
@@ -84,12 +84,12 @@ fn apply_patches(
     for patch_item in patches.iter() {
         let patch_map = patch_item.as_object().ok_or_else(|| {
             diagnosed_error!(
-                "expected each item in 'patch' array to be a map with 'offset', 'length', and 'bytes' fields"
+                "expected each item in 'patch_raw' array to be a map with 'offset', 'length', 'field_value', and 'field_type' fields"
             )
         })?;
 
-        let PatchAccountData { offset, length, field_value, field_type } =
-            PatchAccountData::from_map(patch_map)?;
+        let PatchRawAccountData { offset, length, field_value, field_type } =
+            PatchRawAccountData::from_map(patch_map)?;
         let range = offset as usize..(offset + length) as usize;
         let bytes = field_value_to_bytes(&field_type, &field_value)?;
         if bytes.len() != length as usize {
@@ -116,31 +116,31 @@ fn apply_patches(
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct PatchAccountData {
+pub struct PatchRawAccountData {
     pub offset: u64,
     pub length: u64,
     pub field_value: Value,
     pub field_type: String,
 }
 
-impl PatchAccountData {
+impl PatchRawAccountData {
     pub fn new(offset: u64, length: u64, field_value: Value, field_type: String) -> Self {
         Self { offset, length, field_value, field_type }
     }
 
     pub fn from_map(map: &IndexMap<String, Value>) -> Result<Self, Diagnostic> {
         let get_field = |key: &str| -> Result<&Value, Diagnostic> {
-            map.get(key).ok_or_else(|| diagnosed_error!("missing '{key}' field in patch item"))
+            map.get(key).ok_or_else(|| diagnosed_error!("missing '{key}' field in patch_raw item"))
         };
 
         let offset = get_field("offset")?
             .as_uint()
-            .ok_or_else(|| diagnosed_error!("expected 'offset' field in patch item to be a u64"))?
+            .ok_or_else(|| diagnosed_error!("expected 'offset' field in patch_raw item to be a u64"))?
             .map_err(|e| diagnosed_error!("{e}"))?;
 
         let length = get_field("length")?
             .as_uint()
-            .ok_or_else(|| diagnosed_error!("expected 'length' field in patch item to be a u64"))?
+            .ok_or_else(|| diagnosed_error!("expected 'length' field in patch_raw item to be a u64"))?
             .map_err(|e| diagnosed_error!("{e}"))?;
 
         let field_value = get_field("field_value")?.clone();
@@ -148,7 +148,7 @@ impl PatchAccountData {
         let field_type = get_field("field_type")?
             .as_string()
             .ok_or_else(|| {
-                diagnosed_error!("expected 'field_type' field in patch item to be a string")
+                diagnosed_error!("expected 'field_type' field in patch_raw item to be a string")
             })?
             .to_string();
 
@@ -296,8 +296,8 @@ impl SurfpoolAccountUpdate {
                 .transpose()?
                 .transpose()?;
 
-            let data_bytes = if let Some(patch) = map.swap_remove("patch") {
-                Some(apply_patches(data_bytes, &patch, prefetched_data, &public_key)?)
+            let data_bytes = if let Some(patch) = map.swap_remove("patch_raw") {
+                Some(apply_patches_raw(data_bytes, &patch, prefetched_data, &public_key)?)
             } else {
                 data_bytes
             };
@@ -353,7 +353,7 @@ impl SurfpoolAccountUpdate {
             .iter()
             .enumerate()
             .filter_map(|(i, update)| {
-                update.get("patch")?;
+                update.get("patch_raw")?;
                 let prefix = format!("failed to parse `set_account` map #{}", i + 1);
                 Some(
                     update
@@ -490,14 +490,14 @@ mod tests {
     }
 
     #[test]
-    fn test_patch_account_data_from_map() -> Result<(), Diagnostic> {
+    fn test_patch_raw_account_data_from_map() -> Result<(), Diagnostic> {
         let mut map = IndexMap::new();
         map.insert("offset".to_string(), Value::Integer(0));
         map.insert("length".to_string(), Value::Integer(4));
         map.insert("field_value".to_string(), Value::String("255".to_string()));
         map.insert("field_type".to_string(), Value::String("u32".to_string()));
 
-        let patch_data = PatchAccountData::from_map(&map)?;
+        let patch_data = PatchRawAccountData::from_map(&map)?;
         assert_eq!(patch_data.offset, 0);
         assert_eq!(patch_data.length, 4);
         assert_eq!(patch_data.field_value, Value::String("255".to_string()));
@@ -520,7 +520,7 @@ mod tests {
             m
         })]));
 
-        map.insert("patch".to_string(), patch);
+        map.insert("patch_raw".to_string(), patch);
 
         let auth_ctx = AuthorizationContext::empty();
         let mut prefetched_data = HashMap::new();
@@ -534,7 +534,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_multiple_patches() -> Result<(), Diagnostic> {
+    fn test_apply_multiple_patches_raw() -> Result<(), Diagnostic> {
         let patch = Value::array(vec![
             Value::object({
                 let mut m = IndexMap::new();
@@ -566,7 +566,7 @@ mod tests {
         let prefetched = HashMap::new();
         let pubkey = pubkey!("11111111111111111111111111111111");
 
-        let result = apply_patches(data, &patch, &prefetched, &pubkey)?;
+        let result = apply_patches_raw(data, &patch, &prefetched, &pubkey)?;
 
         assert_eq!(&result[0..4], &100u32.to_le_bytes());
         assert_eq!(&result[4..8], &200u32.to_le_bytes());
@@ -576,7 +576,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_patches_uses_provided_data_over_prefetched() -> Result<(), Diagnostic> {
+    fn test_apply_patches_raw_uses_provided_data_over_prefetched() -> Result<(), Diagnostic> {
         let patch = Value::array(vec![Value::object({
             let mut m = IndexMap::new();
             m.insert("offset".to_string(), Value::Integer(0));
@@ -592,14 +592,14 @@ mod tests {
         let mut prefetched = HashMap::new();
         prefetched.insert(pubkey.to_string(), vec![0xAA; 4]);
 
-        let result = apply_patches(provided_data, &patch, &prefetched, &pubkey)?;
+        let result = apply_patches_raw(provided_data, &patch, &prefetched, &pubkey)?;
         assert_eq!(result[0], 42);
         assert_eq!(&result[1..4], &[0xFF; 3]);
         Ok(())
     }
 
     #[test]
-    fn test_apply_patches_falls_back_to_prefetched() -> Result<(), Diagnostic> {
+    fn test_apply_patches_raw_falls_back_to_prefetched() -> Result<(), Diagnostic> {
         let patch = Value::array(vec![Value::object({
             let mut m = IndexMap::new();
             m.insert("offset".to_string(), Value::Integer(0));
@@ -614,7 +614,7 @@ mod tests {
         let mut prefetched = HashMap::new();
         prefetched.insert(pubkey.to_string(), vec![0xBB; 4]);
 
-        let result = apply_patches(None, &patch, &prefetched, &pubkey)?;
+        let result = apply_patches_raw(None, &patch, &prefetched, &pubkey)?;
         assert_eq!(result[0], 42);
         assert_eq!(&result[1..4], &[0xBB; 3]);
         Ok(())

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -27,80 +27,91 @@ macro_rules! parse_num {
     }};
 }
 
-#[cfg(test)]
-mod tests {
-    use solana_pubkey::pubkey;
+fn field_value_to_bytes(field_type: &str, field_value: &Value) -> Result<Vec<u8>, Diagnostic> {
+    match field_type {
+        "u8" => Ok(parse_num!(u8, &field_value.to_string())),
+        "i8" => Ok(parse_num!(i8, &field_value.to_string())),
+        "u16" => Ok(parse_num!(u16, &field_value.to_string())),
+        "i16" => Ok(parse_num!(i16, &field_value.to_string())),
+        "u32" => Ok(parse_num!(u32, &field_value.to_string())),
+        "i32" => Ok(parse_num!(i32, &field_value.to_string())),
+        "u64" => Ok(parse_num!(u64, &field_value.to_string())),
+        "i64" => Ok(parse_num!(i64, &field_value.to_string())),
+        "u128" => Ok(parse_num!(u128, &field_value.to_string())),
+        "i128" => Ok(parse_num!(i128, &field_value.to_string())),
+        "f32" => Ok(parse_num!(f32, &field_value.to_string())),
+        "f64" => Ok(parse_num!(f64, &field_value.to_string())),
+        "pubkey" => {
+            let pubkey = Pubkey::from_str(&field_value.to_string())
+                .map_err(|e| diagnosed_error!("failed to parse field_value as Pubkey: {e}"))?;
+            Ok(pubkey.to_bytes().to_vec())
+        }
+        "string" => Ok(field_value.to_string().into_bytes()),
+        "boolean" => {
+            let b = bool::from_str(&field_value.to_string())
+                .map_err(|e| diagnosed_error!("failed to parse field_value as boolean: {e}"))?;
+            Ok(vec![b as u8])
+        }
+        "buffer" => hex::decode(&field_value.to_string())
+            .map_err(|e| diagnosed_error!("failed to parse field_value as hex string: {e}")),
+        _ => Err(diagnosed_error!(
+            "invalid 'field_type' field in patch item: must be one of \
+            'u8', 'i8', 'u16', 'i16', 'u32', 'i32', 'u64', 'i64', \
+            'u128', 'i128', 'f32', 'f64', 'pubkey', 'string', 'boolean', or 'buffer'"
+        )),
+    }
+}
 
-    #[allow(unused_imports)]
-    use super::*;
-    #[test]
-    fn test_parse_num() -> Result<(), Diagnostic> {
-        assert_eq!(parse_num!(u8, "255"), vec![255]);
-        assert_eq!(parse_num!(i8, "-128"), vec![128]);
-        assert_eq!(parse_num!(u16, "65535"), vec![255, 255]);
-        assert_eq!(parse_num!(i16, "-32768"), vec![0, 128]);
-        assert_eq!(parse_num!(u32, "4294967295"), vec![255, 255, 255, 255]);
-        assert_eq!(parse_num!(i32, "-2147483648"), vec![0, 0, 0, 128]);
-        assert_eq!(
-            parse_num!(u64, "18446744073709551615"),
-            vec![255, 255, 255, 255, 255, 255, 255, 255]
-        );
-        assert_eq!(parse_num!(i64, "-9223372036854775808"), vec![0, 0, 0, 0, 0, 0, 0, 128]);
-        assert_eq!(parse_num!(u128, "340282366920938463463374607431768211455"), vec![255; 16]);
-        assert_eq!(parse_num!(i128, "0"), vec![0; 16]);
-        assert_eq!(parse_num!(f32, "3.14"), 3.14f32.to_le_bytes().to_vec());
-        assert_eq!(parse_num!(f64, "3.14"), 3.14f64.to_le_bytes().to_vec());
-        Ok(())
+fn apply_patches(
+    data_bytes: Option<Vec<u8>>,
+    patch: &Value,
+    prefetched_data: &HashMap<String, Vec<u8>>,
+    public_key: &Pubkey,
+) -> Result<Vec<u8>, Diagnostic> {
+    let patches = patch.as_array().ok_or_else(|| {
+        diagnosed_error!(
+            "expected 'patch' field to be a map with 'offset', 'length', and 'bytes' fields"
+        )
+    })?;
+
+    let mut data_bytes = match data_bytes {
+        Some(d) => d,
+        None => prefetched_data.get(&public_key.to_string()).cloned().ok_or_else(|| {
+            diagnosed_error!("account data must be provided or prefetched for patching")
+        })?,
+    };
+
+    for patch_item in patches.iter() {
+        let patch_map = patch_item.as_object().ok_or_else(|| {
+            diagnosed_error!(
+                "expected each item in 'patch' array to be a map with 'offset', 'length', and 'bytes' fields"
+            )
+        })?;
+
+        let PatchAccountData { offset, length, field_value, field_type } =
+            PatchAccountData::from_map(patch_map)?;
+        let range = offset as usize..(offset + length) as usize;
+        let bytes = field_value_to_bytes(&field_type, &field_value)?;
+        if bytes.len() != length as usize {
+            return Err(diagnosed_error!(
+                "patch field_type '{}' produced {} bytes, but 'length' was set to {}",
+                field_type,
+                bytes.len(),
+                length
+            ));
+        }
+        if (offset + length) as usize > data_bytes.len() {
+            return Err(diagnosed_error!(
+                "patch range {}..{} exceeds account data length ({})",
+                offset,
+                offset + length,
+                data_bytes.len()
+            ));
+        }
+        data_bytes[range].copy_from_slice(&bytes);
     }
 
-    #[test]
-    fn test_patch_account_data_from_map() -> Result<(), Diagnostic> {
-        let mut map = IndexMap::new();
-        map.insert("offset".to_string(), Value::Integer(0));
-        map.insert("length".to_string(), Value::Integer(4));
-        map.insert("field_value".to_string(), Value::String("255".to_string()));
-        map.insert("field_type".to_string(), Value::String("u32".to_string()));
-
-        let patch_data = PatchAccountData::from_map(&map)?;
-        assert_eq!(patch_data.offset, 0);
-        assert_eq!(patch_data.length, 4);
-        assert_eq!(patch_data.field_value, Value::String("255".to_string()));
-        assert_eq!(patch_data.field_type, "u32");
-        Ok(())
-    }
-
-    #[test]
-    fn test_surfpool_account_update_from_map_with_patch_application() -> Result<(), Diagnostic> {
-        let mut map = IndexMap::new();
-        const PUBKEY: Pubkey = pubkey!("11111111111111111111111111111111");
-        map.insert("public_key".to_string(), SvmValue::pubkey(PUBKEY.to_bytes().to_vec()));
-
-        let patch = Value::Array(Box::new(vec![
-            (Value::Object({
-                let mut m = IndexMap::new();
-                m.insert("offset".to_string(), Value::Integer(0));
-                m.insert("length".to_string(), Value::Integer(4));
-                m.insert("field_value".to_string(), Value::String("1".to_string()));
-                m.insert("field_type".to_string(), Value::String("u32".to_string()));
-                m
-            })),
-        ]));
-
-        map.insert("patch".to_string(), patch);
-
-        let auth_ctx = AuthorizationContext::empty();
-        let mut prefetched_data = HashMap::new();
-
-        prefetched_data.insert(
-            PUBKEY.to_string(),
-            vec![0; 8], // Original data is 8 bytes of zeros
-        );
-        let account_update =
-            SurfpoolAccountUpdate::from_map(&mut map, &auth_ctx, &prefetched_data)?;
-        assert_eq!(account_update.public_key.to_string(), PUBKEY.to_string());
-        assert_eq!(account_update.data, Some("0100000000000000".to_string())); // 1 in little-endian hex
-        Ok(())
-    }
+    Ok(data_bytes)
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -286,88 +297,7 @@ impl SurfpoolAccountUpdate {
                 .transpose()?;
 
             let data_bytes = if let Some(patch) = map.swap_remove("patch") {
-                let patches = patch.as_array().ok_or_else(|| {
-                    diagnosed_error!("expected 'patch' field to be a map with 'offset', 'length', and 'bytes' fields")
-                })?;
-
-                let mut data_bytes = match data_bytes {
-                    Some(d) => d,
-                    None => {
-                        prefetched_data.get(&public_key.to_string()).cloned().ok_or_else(|| {
-                            diagnosed_error!(
-                                "account data must be provided or prefetched for patching"
-                            )
-                        })?
-                    }
-                };
-
-                for patch_item in patches.iter() {
-                    let patch_map = patch_item
-            .as_object()
-            .ok_or_else(|| diagnosed_error!(
-                "expected each item in 'patch' array to be a map with 'offset', 'length', and 'bytes' fields"
-            ))?;
-
-                    let PatchAccountData { offset, length, field_value, field_type } =
-                        PatchAccountData::from_map(patch_map)?;
-                    let range = offset as usize..(offset + length) as usize;
-                    let bytes = match field_type.as_str() {
-                        "u8" => parse_num!(u8, &field_value.to_string()),
-                        "i8" => parse_num!(i8, &field_value.to_string()),
-                        "u16" => parse_num!(u16, &field_value.to_string()),
-                        "i16" => parse_num!(i16, &field_value.to_string()),
-                        "u32" => parse_num!(u32, &field_value.to_string()),
-                        "i32" => parse_num!(i32, &field_value.to_string()),
-                        "u64" => parse_num!(u64, &field_value.to_string()),
-                        "i64" => parse_num!(i64, &field_value.to_string()),
-                        "u128" => parse_num!(u128, &field_value.to_string()),
-                        "i128" => parse_num!(i128, &field_value.to_string()),
-                        "f32" => parse_num!(f32, &field_value.to_string()),
-                        "f64" => parse_num!(f64, &field_value.to_string()),
-                        "pubkey" => {
-                            let pubkey = Pubkey::from_str(&field_value.to_string()).map_err(|e| {
-                                diagnosed_error!("failed to parse field_value as Pubkey: {e}")
-                            })?;
-                            pubkey.to_bytes().to_vec()
-                        }
-                        "string" => field_value.to_string().into_bytes(),
-                        "boolean" => {
-                            let b = bool::from_str(&field_value.to_string()).map_err(|e| {
-                                diagnosed_error!("failed to parse field_value as boolean: {e}")
-                            })?;
-                            vec![b as u8]
-                        }
-                        "buffer" => hex::decode(&field_value.to_string()).map_err(|e| {
-                            diagnosed_error!("failed to parse field_value as hex string: {e}")
-                        })?,
-                        _ => {
-                            return Err(diagnosed_error!(
-                                "invalid 'field_type' field in patch item: must be one of \
-                                'u8', 'i8', 'u16', 'i16', 'u32', 'i32', 'u64', 'i64', \
-                                'u128', 'i128', 'f32', 'f64', 'pubkey', 'string', 'boolean', or 'buffer'"
-                            ))
-                        }
-                    };
-                    if bytes.len() != length as usize {
-                        return Err(diagnosed_error!(
-                            "patch field_type '{}' produced {} bytes, but 'length' was set to {}",
-                            field_type,
-                            bytes.len(),
-                            length
-                        ));
-                    }
-                    if (offset + length) as usize > data_bytes.len() {
-                        return Err(diagnosed_error!(
-                            "patch range {}..{} exceeds account data length ({})",
-                            offset,
-                            offset + length,
-                            data_bytes.len()
-                        ));
-                    }
-                    data_bytes[range].copy_from_slice(&bytes);
-                }
-
-                Some(data_bytes)
+                Some(apply_patches(data_bytes, &patch, prefetched_data, &public_key)?)
             } else {
                 data_bytes
             };
@@ -386,19 +316,17 @@ impl SurfpoolAccountUpdate {
         }
     }
 
-    // This function checks if any of the account updates require prefetched data and fetches it if needed. It returns a map of account public keys to their prefetched data.
-    pub async fn get_accounts_data_if_needed(
+    fn get_account_update_maps(
         values: &ValueStore,
-        rpc_client: &RpcClient,
-    ) -> Result<HashMap<String, Vec<u8>>, Diagnostic> {
+    ) -> Result<Option<Vec<IndexMap<String, Value>>>, Diagnostic> {
         let account_update_data = match values.get_value(SET_ACCOUNT) {
-            None => return Ok(HashMap::new()),
+            None => return Ok(None),
             Some(v) => {
                 v.as_map().ok_or_else(|| diagnosed_error!("'set_account' must be a map type"))?
             }
         };
 
-        let account_updates = account_update_data
+        let maps = account_update_data
             .iter()
             .map(|i| {
                 i.as_object()
@@ -406,6 +334,20 @@ impl SurfpoolAccountUpdate {
                     .ok_or_else(|| diagnosed_error!("'set_account' must be a map type"))
             })
             .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Some(maps))
+    }
+
+    /// Checks if any of the account updates require prefetched data and fetches it if needed.
+    /// Returns a map of account public keys to their prefetched data.
+    pub async fn get_accounts_data_if_needed(
+        values: &ValueStore,
+        rpc_client: &RpcClient,
+    ) -> Result<HashMap<String, Vec<u8>>, Diagnostic> {
+        let account_updates = match Self::get_account_update_maps(values)? {
+            None => return Ok(HashMap::new()),
+            Some(maps) => maps,
+        };
 
         let accounts_to_fetch = account_updates
         .iter()
@@ -450,25 +392,12 @@ impl SurfpoolAccountUpdate {
         auth_ctx: &AuthorizationContext,
         prefetched_data: HashMap<String, Vec<u8>>,
     ) -> Result<Vec<Self>, Diagnostic> {
-        let mut account_updates = vec![];
-
-        let account_update_data = values
-            .get_value(SET_ACCOUNT)
-            .map(|v| v.as_map().ok_or_else(|| diagnosed_error!("'set_account' must be a map type")))
-            .transpose()?;
-
-        let Some(account_update_data) = account_update_data else {
-            return Ok(vec![]);
+        let mut account_update_data = match Self::get_account_update_maps(values)? {
+            None => return Ok(vec![]),
+            Some(maps) => maps,
         };
 
-        let mut account_update_data = account_update_data
-            .iter()
-            .map(|i| {
-                i.as_object()
-                    .map(|o| o.clone())
-                    .ok_or(diagnosed_error!("'set_account' must be a map type"))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
+        let mut account_updates = vec![];
 
         for (i, account_update) in account_update_data.iter_mut().enumerate() {
             let prefix = format!("failed to parse `set_account` map #{}", i + 1);
@@ -526,6 +455,81 @@ impl SurfpoolAccountUpdate {
             let _ = account_update.send_request(rpc_client).await?;
             account_update.update_status(logger, i, account_updates.len());
         }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use solana_pubkey::pubkey;
+
+    #[allow(unused_imports)]
+    use super::*;
+
+    #[test]
+    fn test_parse_num() -> Result<(), Diagnostic> {
+        assert_eq!(parse_num!(u8, "255"), vec![255]);
+        assert_eq!(parse_num!(i8, "-128"), vec![128]);
+        assert_eq!(parse_num!(u16, "65535"), vec![255, 255]);
+        assert_eq!(parse_num!(i16, "-32768"), vec![0, 128]);
+        assert_eq!(parse_num!(u32, "4294967295"), vec![255, 255, 255, 255]);
+        assert_eq!(parse_num!(i32, "-2147483648"), vec![0, 0, 0, 128]);
+        assert_eq!(
+            parse_num!(u64, "18446744073709551615"),
+            vec![255, 255, 255, 255, 255, 255, 255, 255]
+        );
+        assert_eq!(parse_num!(i64, "-9223372036854775808"), vec![0, 0, 0, 0, 0, 0, 0, 128]);
+        assert_eq!(parse_num!(u128, "340282366920938463463374607431768211455"), vec![255; 16]);
+        assert_eq!(parse_num!(i128, "0"), vec![0; 16]);
+        assert_eq!(parse_num!(f32, "3.14"), 3.14f32.to_le_bytes().to_vec());
+        assert_eq!(parse_num!(f64, "3.14"), 3.14f64.to_le_bytes().to_vec());
+        Ok(())
+    }
+
+    #[test]
+    fn test_patch_account_data_from_map() -> Result<(), Diagnostic> {
+        let mut map = IndexMap::new();
+        map.insert("offset".to_string(), Value::Integer(0));
+        map.insert("length".to_string(), Value::Integer(4));
+        map.insert("field_value".to_string(), Value::String("255".to_string()));
+        map.insert("field_type".to_string(), Value::String("u32".to_string()));
+
+        let patch_data = PatchAccountData::from_map(&map)?;
+        assert_eq!(patch_data.offset, 0);
+        assert_eq!(patch_data.length, 4);
+        assert_eq!(patch_data.field_value, Value::String("255".to_string()));
+        assert_eq!(patch_data.field_type, "u32");
+        Ok(())
+    }
+
+    #[test]
+    fn test_surfpool_account_update_from_map_with_patch_application() -> Result<(), Diagnostic> {
+        let mut map = IndexMap::new();
+        const PUBKEY: Pubkey = pubkey!("11111111111111111111111111111111");
+        map.insert("public_key".to_string(), SvmValue::pubkey(PUBKEY.to_bytes().to_vec()));
+
+        let patch = Value::Array(Box::new(vec![Value::Object({
+            let mut m = IndexMap::new();
+            m.insert("offset".to_string(), Value::Integer(0));
+            m.insert("length".to_string(), Value::Integer(4));
+            m.insert("field_value".to_string(), Value::String("1".to_string()));
+            m.insert("field_type".to_string(), Value::String("u32".to_string()));
+            m
+        })]));
+
+        map.insert("patch".to_string(), patch);
+
+        let auth_ctx = AuthorizationContext::empty();
+        let mut prefetched_data = HashMap::new();
+
+        prefetched_data.insert(
+            PUBKEY.to_string(),
+            vec![0; 8], // Original data is 8 bytes of zeros
+        );
+        let account_update =
+            SurfpoolAccountUpdate::from_map(&mut map, &auth_ctx, &prefetched_data)?;
+        assert_eq!(account_update.public_key.to_string(), PUBKEY.to_string());
+        assert_eq!(account_update.data, Some("0100000000000000".to_string())); // 1 in little-endian hex
         Ok(())
     }
 }

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -21,7 +21,7 @@ use crate::constants::SET_ACCOUNT;
 macro_rules! parse_num {
     ($type:ty, $value:expr) => {{
         let num = <$type>::from_str($value).map_err(|e| {
-            diagnosed_error!("failed to parse field_value as {}: {e}", stringify!($type))
+            diagnosed_error!("failed to parse value as {}: {e}", stringify!($type))
         })?;
         num.to_le_bytes().to_vec()
     }};
@@ -43,19 +43,19 @@ fn field_value_to_bytes(field_type: &str, field_value: &Value) -> Result<Vec<u8>
         "f64" => Ok(parse_num!(f64, &field_value.to_string())),
         "pubkey" => {
             let pubkey = Pubkey::from_str(&field_value.to_string())
-                .map_err(|e| diagnosed_error!("failed to parse field_value as Pubkey: {e}"))?;
+                .map_err(|e| diagnosed_error!("failed to parse value as Pubkey: {e}"))?;
             Ok(pubkey.to_bytes().to_vec())
         }
         "string" => Ok(field_value.to_string().into_bytes()),
         "boolean" => {
             let b = bool::from_str(&field_value.to_string())
-                .map_err(|e| diagnosed_error!("failed to parse field_value as boolean: {e}"))?;
+                .map_err(|e| diagnosed_error!("failed to parse value as boolean: {e}"))?;
             Ok(vec![b as u8])
         }
         "buffer" => hex::decode(&field_value.to_string())
-            .map_err(|e| diagnosed_error!("failed to parse field_value as hex string: {e}")),
+            .map_err(|e| diagnosed_error!("failed to parse value as hex string: {e}")),
         _ => Err(diagnosed_error!(
-            "invalid 'field_type' field in patch_raw item: must be one of \
+            "invalid 'type' field in patch_raw: must be one of \
             'u8', 'i8', 'u16', 'i16', 'u32', 'i32', 'u64', 'i64', \
             'u128', 'i128', 'f32', 'f64', 'pubkey', 'string', 'boolean', or 'buffer'"
         )),
@@ -70,7 +70,7 @@ fn apply_patches_raw(
 ) -> Result<Option<Vec<u8>>, Diagnostic> {
     let patches = patch.as_array().ok_or_else(|| {
         diagnosed_error!(
-            "expected 'patch_raw' to contain maps with 'offset', 'length', 'field_value', and 'field_type' fields"
+            "expected 'patch_raw' to contain maps with 'offset', 'length', 'value', and 'type' fields"
         )
     })?;
 
@@ -96,18 +96,18 @@ fn apply_patches_raw(
     for patch_item in patches.iter() {
         let patch_map = patch_item.as_object().ok_or_else(|| {
             diagnosed_error!(
-                "expected each 'patch_raw' item to be a map with 'offset', 'length', 'field_value', and 'field_type' fields"
+                "expected each 'patch_raw' block to be a map with 'offset', 'length', 'value', and 'type' fields"
             )
         })?;
 
-        let PatchRawAccountData { offset, length, field_value, field_type } =
+        let PatchRawAccountData { offset, length, value, r#type } =
             PatchRawAccountData::from_map(patch_map)?;
         let range = offset as usize..(offset + length) as usize;
-        let bytes = field_value_to_bytes(&field_type, &field_value)?;
+        let bytes = field_value_to_bytes(&r#type, &value)?;
         if bytes.len() != length as usize {
             return Err(diagnosed_error!(
-                "patch field_type '{}' produced {} bytes, but 'length' was set to {}",
-                field_type,
+                "patch type '{}' produced {} bytes, but 'length' was set to {}",
+                r#type,
                 bytes.len(),
                 length
             ));
@@ -131,40 +131,40 @@ fn apply_patches_raw(
 pub struct PatchRawAccountData {
     pub offset: u64,
     pub length: u64,
-    pub field_value: Value,
-    pub field_type: String,
+    pub value: Value,
+    pub r#type: String,
 }
 
 impl PatchRawAccountData {
-    pub fn new(offset: u64, length: u64, field_value: Value, field_type: String) -> Self {
-        Self { offset, length, field_value, field_type }
+    pub fn new(offset: u64, length: u64, value: Value, r#type: String) -> Self {
+        Self { offset, length, value, r#type }
     }
 
     pub fn from_map(map: &IndexMap<String, Value>) -> Result<Self, Diagnostic> {
         let get_field = |key: &str| -> Result<&Value, Diagnostic> {
-            map.get(key).ok_or_else(|| diagnosed_error!("missing '{key}' field in patch_raw item"))
+            map.get(key).ok_or_else(|| diagnosed_error!("missing '{key}' field in patch_raw block"))
         };
 
         let offset = get_field("offset")?
             .as_uint()
-            .ok_or_else(|| diagnosed_error!("expected 'offset' field in patch_raw item to be a u64"))?
+            .ok_or_else(|| diagnosed_error!("expected 'offset' field in patch_raw block to be a u64"))?
             .map_err(|e| diagnosed_error!("{e}"))?;
 
         let length = get_field("length")?
             .as_uint()
-            .ok_or_else(|| diagnosed_error!("expected 'length' field in patch_raw item to be a u64"))?
+            .ok_or_else(|| diagnosed_error!("expected 'length' field in patch_raw block to be a u64"))?
             .map_err(|e| diagnosed_error!("{e}"))?;
 
-        let field_value = get_field("field_value")?.clone();
+        let value = get_field("value")?.clone();
 
-        let field_type = get_field("field_type")?
+        let r#type = get_field("type")?
             .as_string()
             .ok_or_else(|| {
-                diagnosed_error!("expected 'field_type' field in patch_raw item to be a string")
+                diagnosed_error!("expected 'type' field in patch_raw block to be a string")
             })?
             .to_string();
 
-        Ok(Self::new(offset, length, field_value, field_type))
+        Ok(Self::new(offset, length, value, r#type))
     }
 }
 
@@ -506,14 +506,14 @@ mod tests {
         let mut map = IndexMap::new();
         map.insert("offset".to_string(), Value::Integer(0));
         map.insert("length".to_string(), Value::Integer(4));
-        map.insert("field_value".to_string(), Value::String("255".to_string()));
-        map.insert("field_type".to_string(), Value::String("u32".to_string()));
+        map.insert("value".to_string(), Value::String("255".to_string()));
+        map.insert("type".to_string(), Value::String("u32".to_string()));
 
         let patch_data = PatchRawAccountData::from_map(&map)?;
         assert_eq!(patch_data.offset, 0);
         assert_eq!(patch_data.length, 4);
-        assert_eq!(patch_data.field_value, Value::String("255".to_string()));
-        assert_eq!(patch_data.field_type, "u32");
+        assert_eq!(patch_data.value, Value::String("255".to_string()));
+        assert_eq!(patch_data.r#type, "u32");
         Ok(())
     }
 
@@ -527,8 +527,8 @@ mod tests {
             let mut m = IndexMap::new();
             m.insert("offset".to_string(), Value::Integer(0));
             m.insert("length".to_string(), Value::Integer(4));
-            m.insert("field_value".to_string(), Value::String("1".to_string()));
-            m.insert("field_type".to_string(), Value::String("u32".to_string()));
+            m.insert("value".to_string(), Value::String("1".to_string()));
+            m.insert("type".to_string(), Value::String("u32".to_string()));
             m
         })]));
 
@@ -552,24 +552,24 @@ mod tests {
                 let mut m = IndexMap::new();
                 m.insert("offset".to_string(), Value::Integer(0));
                 m.insert("length".to_string(), Value::Integer(4));
-                m.insert("field_value".to_string(), Value::String("100".to_string()));
-                m.insert("field_type".to_string(), Value::String("u32".to_string()));
+                m.insert("value".to_string(), Value::String("100".to_string()));
+                m.insert("type".to_string(), Value::String("u32".to_string()));
                 m
             }),
             Value::object({
                 let mut m = IndexMap::new();
                 m.insert("offset".to_string(), Value::Integer(4));
                 m.insert("length".to_string(), Value::Integer(4));
-                m.insert("field_value".to_string(), Value::String("200".to_string()));
-                m.insert("field_type".to_string(), Value::String("u32".to_string()));
+                m.insert("value".to_string(), Value::String("200".to_string()));
+                m.insert("type".to_string(), Value::String("u32".to_string()));
                 m
             }),
             Value::object({
                 let mut m = IndexMap::new();
                 m.insert("offset".to_string(), Value::Integer(8));
                 m.insert("length".to_string(), Value::Integer(1));
-                m.insert("field_value".to_string(), Value::String("true".to_string()));
-                m.insert("field_type".to_string(), Value::String("boolean".to_string()));
+                m.insert("value".to_string(), Value::String("true".to_string()));
+                m.insert("type".to_string(), Value::String("boolean".to_string()));
                 m
             }),
         ]);
@@ -593,8 +593,8 @@ mod tests {
             let mut m = IndexMap::new();
             m.insert("offset".to_string(), Value::Integer(0));
             m.insert("length".to_string(), Value::Integer(1));
-            m.insert("field_value".to_string(), Value::String("42".to_string()));
-            m.insert("field_type".to_string(), Value::String("u8".to_string()));
+            m.insert("value".to_string(), Value::String("42".to_string()));
+            m.insert("type".to_string(), Value::String("u8".to_string()));
             m
         })]);
 
@@ -616,8 +616,8 @@ mod tests {
             let mut m = IndexMap::new();
             m.insert("offset".to_string(), Value::Integer(0));
             m.insert("length".to_string(), Value::Integer(1));
-            m.insert("field_value".to_string(), Value::String("42".to_string()));
-            m.insert("field_type".to_string(), Value::String("u8".to_string()));
+            m.insert("value".to_string(), Value::String("42".to_string()));
+            m.insert("type".to_string(), Value::String("u8".to_string()));
             m
         })]);
 
@@ -638,8 +638,8 @@ mod tests {
             let mut m = IndexMap::new();
             m.insert("offset".to_string(), Value::Integer(0));
             m.insert("length".to_string(), Value::Integer(1));
-            m.insert("field_value".to_string(), Value::String("42".to_string()));
-            m.insert("field_type".to_string(), Value::String("u8".to_string()));
+            m.insert("value".to_string(), Value::String("42".to_string()));
+            m.insert("type".to_string(), Value::String("u8".to_string()));
             m
         })]);
 
@@ -659,8 +659,8 @@ mod tests {
             let mut m = IndexMap::new();
             m.insert("offset".to_string(), Value::Integer(0));
             m.insert("length".to_string(), Value::Integer(1));
-            m.insert("field_value".to_string(), Value::String("42".to_string()));
-            m.insert("field_type".to_string(), Value::String("u8".to_string()));
+            m.insert("value".to_string(), Value::String("42".to_string()));
+            m.insert("type".to_string(), Value::String("u8".to_string()));
             m
         })]);
 

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -17,6 +17,54 @@ use txtx_addon_kit::{
 use txtx_addon_network_svm_types::SvmValue;
 
 use crate::constants::SET_ACCOUNT;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PatchAccountData {
+    pub offset: u64,
+    pub length: u64,
+    pub bytes: Vec<u8>,
+}
+
+impl PatchAccountData {
+    pub fn new(offset: u64, length: u64, bytes: Vec<u8>) -> Self {
+        Self { offset, length, bytes }
+    }
+
+    pub fn from_map(map: &IndexMap<String, Value>) -> Result<Self, Diagnostic> {
+        let some_offset = map
+            .get("offset")
+            .ok_or_else(|| diagnosed_error!("missing 'offset' field in patch item"))?;
+        let offset =
+            some_offset.as_uint().map(|r| r.map_err(|e| diagnosed_error!("{e}"))).ok_or_else(
+                || diagnosed_error!("expected 'offset' field in patch item to be a u64"),
+            )??;
+
+        let some_length = map
+            .get("length")
+            .ok_or_else(|| diagnosed_error!("missing 'length' field in patch item"))?;
+        let length =
+            some_length.as_uint().map(|r| r.map_err(|e| diagnosed_error!("{e}"))).ok_or_else(
+                || diagnosed_error!("expected 'length' field in patch item to be a u64"),
+            )??;
+
+        let some_bytes = map
+            .get("bytes")
+            .ok_or_else(|| diagnosed_error!("missing 'bytes' field in patch item"))?;
+        let bytes = some_bytes
+            .as_string()
+            .ok_or_else(|| {
+                diagnosed_error!("expected 'bytes' field in patch item to be a hex string")
+            })
+            .and_then(|s| {
+                hex::decode(s).map_err(|e| {
+                    diagnosed_error!("invalid hex string in 'bytes' field of patch item: {e}")
+                })
+            })?;
+
+        Ok(Self::new(offset, length, bytes))
+    }
+}
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -59,6 +107,7 @@ impl SurfpoolAccountUpdate {
     pub fn from_map(
         map: &mut IndexMap<String, Value>,
         auth_ctx: &AuthorizationContext,
+        prefetched_data: &HashMap<String, Vec<u8>>,
     ) -> Result<Self, Diagnostic> {
         let some_public_key = map.swap_remove("public_key");
 
@@ -127,7 +176,7 @@ impl SurfpoolAccountUpdate {
                 .transpose()?;
 
             let some_data = map.swap_remove("data");
-            let data = some_data.map(|v| hex::encode(v.to_be_bytes()));
+            let data_bytes = some_data.map(|v| v.to_be_bytes());
 
             let some_owner = map.swap_remove("owner");
             let owner = some_owner
@@ -157,6 +206,44 @@ impl SurfpoolAccountUpdate {
                 .transpose()?
                 .transpose()?;
 
+            let data_bytes = if let Some(patch) = map.swap_remove("patch") {
+                let patches = patch.as_array().ok_or_else(|| {
+                    diagnosed_error!(
+            "expected 'patch' field to be a map with 'offset', 'length', and 'bytes' fields"
+        )
+                })?;
+
+                let mut data_bytes = match data_bytes {
+                    Some(d) => d,
+                    None => {
+                        prefetched_data.get(&public_key.to_string()).cloned().ok_or_else(|| {
+                            diagnosed_error!(
+                                "account data must be provided or prefetched for patching"
+                            )
+                        })?
+                    }
+                };
+
+                for patch_item in patches.iter() {
+                    let patch_map = patch_item
+            .as_object()
+            .ok_or_else(|| diagnosed_error!(
+                "expected each item in 'patch' array to be a map with 'offset', 'length', and 'bytes' fields"
+            ))?;
+
+                    let PatchAccountData { offset, length, bytes } =
+                        PatchAccountData::from_map(patch_map)?;
+                    let range = offset as usize..(offset + length) as usize;
+                    data_bytes[range].copy_from_slice(&bytes);
+                }
+
+                Some(data_bytes)
+            } else {
+                data_bytes
+            };
+
+            let data = data_bytes.map(|d| hex::encode(d));
+
             if lamports.is_none()
                 && data.is_none()
                 && owner.is_none()
@@ -169,9 +256,69 @@ impl SurfpoolAccountUpdate {
         }
     }
 
+    // This function checks if any of the account updates require prefetched data and fetches it if needed. It returns a map of account public keys to their prefetched data.
+    pub async fn get_accounts_data_if_needed(
+        values: &ValueStore,
+        rpc_client: &RpcClient,
+    ) -> Result<HashMap<String, Vec<u8>>, Diagnostic> {
+        let account_update_data = match values.get_value(SET_ACCOUNT) {
+            None => return Ok(HashMap::new()),
+            Some(v) => {
+                v.as_map().ok_or_else(|| diagnosed_error!("'set_account' must be a map type"))?
+            }
+        };
+
+        let account_updates = account_update_data
+            .iter()
+            .map(|i| {
+                i.as_object()
+                    .cloned()
+                    .ok_or_else(|| diagnosed_error!("'set_account' must be a map type"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let accounts_to_fetch = account_updates
+        .iter()
+        .enumerate()
+        .filter_map(|(i, update)| {
+            update.get("patch")?;
+            let prefix = format!("failed to parse `set_account` map #{}", i + 1);
+            Some(
+                update
+                    .get("public_key")
+                    .ok_or_else(|| {
+                        diagnosed_error!(
+                            "{prefix} missing required 'public_key' field and 'pubkey' field in account file"
+                        )
+                    })
+                    .and_then(|pk| {
+                        SvmValue::to_pubkey(pk)
+                            .map_err(|e| diagnosed_error!("{prefix} invalid 'public_key' field: {e}"))
+                    }),
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+        if accounts_to_fetch.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let accounts_data = rpc_client
+            .get_multiple_accounts(&accounts_to_fetch)
+            .await
+            .map_err(|e| diagnosed_error!("failed to prefetch account infos: {e}"))?
+            .into_iter()
+            .zip(accounts_to_fetch.iter())
+            .filter_map(|(acc, pubkey)| acc.map(|a| (pubkey.to_string(), a.data)))
+            .collect();
+
+        Ok(accounts_data)
+    }
+
     pub fn parse_value_store(
         values: &ValueStore,
         auth_ctx: &AuthorizationContext,
+        prefetched_data: HashMap<String, Vec<u8>>,
     ) -> Result<Vec<Self>, Diagnostic> {
         let mut account_updates = vec![];
 
@@ -195,8 +342,9 @@ impl SurfpoolAccountUpdate {
 
         for (i, account_update) in account_update_data.iter_mut().enumerate() {
             let prefix = format!("failed to parse `set_account` map #{}", i + 1);
-            let account = SurfpoolAccountUpdate::from_map(account_update, auth_ctx)
-                .map_err(|e| diagnosed_error!("{prefix}: {e}"))?;
+            let account =
+                SurfpoolAccountUpdate::from_map(account_update, auth_ctx, &prefetched_data)
+                    .map_err(|e| diagnosed_error!("{prefix}: {e}"))?;
 
             account_updates.push(account);
         }

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -18,18 +18,27 @@ use txtx_addon_network_svm_types::SvmValue;
 
 use crate::constants::SET_ACCOUNT;
 
+macro_rules! parse_num {
+    ($type:ty, $value:expr) => {{
+        let num = <$type>::from_str($value).map_err(|e| {
+            diagnosed_error!("failed to parse field_value as {}: {e}", stringify!($type))
+        })?;
+        num.to_le_bytes().to_vec()
+    }};
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchAccountData {
     pub offset: u64,
     pub length: u64,
-    pub bytes: String,
-    pub patch_type: String,
+    pub field_value: String,
+    pub field_type: String,
 }
 
 impl PatchAccountData {
-    pub fn new(offset: u64, length: u64, bytes: String, patch_type: String) -> Self {
-        Self { offset, length, bytes, patch_type }
+    pub fn new(offset: u64, length: u64, field_value: String, field_type: String) -> Self {
+        Self { offset, length, field_value, field_type }
     }
 
     pub fn from_map(map: &IndexMap<String, Value>) -> Result<Self, Diagnostic> {
@@ -49,27 +58,27 @@ impl PatchAccountData {
                 || diagnosed_error!("expected 'length' field in patch item to be a u64"),
             )??;
 
-        let some_bytes = map
-            .get("bytes")
-            .ok_or_else(|| diagnosed_error!("missing 'bytes' field in patch item"))?;
-        let bytes = some_bytes
+        let some_field_value = map
+            .get("field_value")
+            .ok_or_else(|| diagnosed_error!("missing 'field_value' field in patch item"))?;
+        let field_value = some_field_value
             .as_string()
             .ok_or_else(|| {
-                diagnosed_error!("expected 'bytes' field in patch item to be a hex string")
+                diagnosed_error!("expected 'field_value' field in patch item to be a hex string")
             })?
             .to_string();
 
-        let some_patch_type = map
-            .get("patch_type")
-            .ok_or_else(|| diagnosed_error!("missing 'patch_type' field in patch item"))?;
-        let patch_type = some_patch_type
+        let some_field_type = map
+            .get("field_type")
+            .ok_or_else(|| diagnosed_error!("missing 'field_type' field in patch item"))?;
+        let field_type = some_field_type
             .as_string()
             .ok_or_else(|| {
-                diagnosed_error!("expected 'patch_type' field in patch item to be a string")
+                diagnosed_error!("expected 'field_type' field in patch item to be a string")
             })?
             .to_string();
 
-        Ok(Self::new(offset, length, bytes, patch_type))
+        Ok(Self::new(offset, length, field_value, field_type))
     }
 }
 
@@ -183,7 +192,7 @@ impl SurfpoolAccountUpdate {
                 .transpose()?;
 
             let some_data = map.swap_remove("data");
-            let data_bytes = some_data.map(|v| v.to_be_bytes());
+            let data_bytes = some_data.map(|v| v.to_le_bytes());
 
             let some_owner = map.swap_remove("owner");
             let owner = some_owner
@@ -238,72 +247,43 @@ impl SurfpoolAccountUpdate {
                 "expected each item in 'patch' array to be a map with 'offset', 'length', and 'bytes' fields"
             ))?;
 
-                    let PatchAccountData { offset, length, bytes, patch_type } =
+                    let PatchAccountData { offset, length, field_value, field_type } =
                         PatchAccountData::from_map(patch_map)?;
                     let range = offset as usize..(offset + length) as usize;
-                    let bytes = match patch_type.as_str() {
-                        "u8" | "i8" => {
-                            let num = u8::from_str(&bytes).map_err(|e| {
-                                diagnosed_error!("failed to parse patch bytes as u8: {e}")
-                            })?;
-                            vec![num]
-                        }
-                        "u16" | "i16" => {
-                            let num = u16::from_str(&bytes).map_err(|e| {
-                                diagnosed_error!("failed to parse patch bytes as u16: {e}")
-                            })?;
-                            num.to_be_bytes().to_vec()
-                        }
-                        "u32" | "i32" => {
-                            let num = u32::from_str(&bytes).map_err(|e| {
-                                diagnosed_error!("failed to parse patch bytes as u32: {e}")
-                            })?;
-                            num.to_be_bytes().to_vec()
-                        }
-                        "u64" | "i64" => {
-                            let num = u64::from_str(&bytes).map_err(|e| {
-                                diagnosed_error!("failed to parse patch bytes as u64: {e}")
-                            })?;
-                            num.to_be_bytes().to_vec()
-                        }
-                        "u128" | "i128" => {
-                            let num = u128::from_str(&bytes).map_err(|e| {
-                                diagnosed_error!("failed to parse patch bytes as u128: {e}")
-                            })?;
-                            num.to_be_bytes().to_vec()
-                        }
-                        "f32" => {
-                            let num = f32::from_str(&bytes).map_err(|e| {
-                                diagnosed_error!("failed to parse patch bytes as f32: {e}")
-                            })?;
-                            num.to_be_bytes().to_vec()
-                        }
-                        "f64" => {
-                            let num = f64::from_str(&bytes).map_err(|e| {
-                                diagnosed_error!("failed to parse patch bytes as f64: {e}")
-                            })?;
-                            num.to_be_bytes().to_vec()
-                        }
+                    let bytes = match field_type.as_str() {
+                        "u8" => parse_num!(u8, &field_value),
+                        "i8" => parse_num!(i8, &field_value),
+                        "u16" => parse_num!(u16, &field_value),
+                        "i16" => parse_num!(i16, &field_value),
+                        "u32" => parse_num!(u32, &field_value),
+                        "i32" => parse_num!(i32, &field_value),
+                        "u64" => parse_num!(u64, &field_value),
+                        "i64" => parse_num!(i64, &field_value),
+                        "u128" => parse_num!(u128, &field_value),
+                        "i128" => parse_num!(i128, &field_value),
+                        "f32" => parse_num!(f32, &field_value),
+                        "f64" => parse_num!(f64, &field_value),
                         "pubkey" => {
-                            let pubkey =
-                                Pubkey::from_str(&bytes).map_err(|e| {
-                                    diagnosed_error!("failed to parse patch bytes as Pubkey: {e}")
-                                })?;
+                            let pubkey = Pubkey::from_str(&field_value).map_err(|e| {
+                                diagnosed_error!("failed to parse field_value as Pubkey: {e}")
+                            })?;
                             pubkey.to_bytes().to_vec()
                         }
-                        "string" => bytes.into_bytes(),
+                        "string" => field_value.into_bytes(),
                         "boolean" => {
-                            let b = bool::from_str(&bytes).map_err(|e| {
-                                diagnosed_error!("failed to parse patch bytes as boolean: {e}")
+                            let b = bool::from_str(&field_value).map_err(|e| {
+                                diagnosed_error!("failed to parse field_value as boolean: {e}")
                             })?;
                             vec![b as u8]
                         }
-                        "buffer" => hex::decode(&bytes).map_err(|e| {
-                            diagnosed_error!("failed to parse patch bytes as hex string: {e}")
+                        "buffer" => hex::decode(&field_value).map_err(|e| {
+                            diagnosed_error!("failed to parse field_value as hex string: {e}")
                         })?,
                         _ => {
                             return Err(diagnosed_error!(
-                                "invalid 'patch_type' field in patch item: must be one of 'u8', 'i8', 'u16', 'i16', 'u32', 'i32', 'u64', 'i64', 'u128', 'i128', 'f32', 'f64', 'pubkey', 'string', 'boolean', or 'buffer'"
+                                "invalid 'patch_type' field in patch item: must be one of \
+                                'u8', 'i8', 'u16', 'i16', 'u32', 'i32', 'u64', 'i64', \
+                                'u128', 'i128', 'f32', 'f64', 'pubkey', 'string', 'boolean', or 'buffer'"
                             ))
                         }
                     };

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -72,9 +72,10 @@ mod tests {
     #[test]
     fn test_surfpool_account_update_from_map_with_patch_application() -> Result<(), Diagnostic> {
         let mut map = IndexMap::new();
+        const PUBKEY: Pubkey = pubkey!("11111111111111111111111111111111");
         map.insert(
             "public_key".to_string(),
-            SvmValue::pubkey(pubkey!("11111111111111111111111111111111").to_bytes().to_vec()),
+            SvmValue::pubkey(PUBKEY.to_bytes().to_vec()),
         );
 
         let patch = Value::Array(Box::new(vec![
@@ -94,12 +95,12 @@ mod tests {
         let mut prefetched_data = HashMap::new();
 
         prefetched_data.insert(
-            "11111111111111111111111111111111".to_string(),
+            PUBKEY.to_string(),
             vec![0; 8], // Original data is 8 bytes of zeros
         );
         let account_update =
             SurfpoolAccountUpdate::from_map(&mut map, &auth_ctx, &prefetched_data)?;
-        assert_eq!(account_update.public_key.to_string(), "11111111111111111111111111111111");
+        assert_eq!(account_update.public_key.to_string(), PUBKEY.to_string());
         assert_eq!(account_update.data, Some("0100000000000000".to_string())); // 1 in little-endian hex
         Ok(())
     }
@@ -120,36 +121,28 @@ impl PatchAccountData {
     }
 
     pub fn from_map(map: &IndexMap<String, Value>) -> Result<Self, Diagnostic> {
-        let some_offset = map
-            .get("offset")
-            .ok_or_else(|| diagnosed_error!("missing 'offset' field in patch item"))?;
-        let offset =
-            some_offset.as_uint().map(|r| r.map_err(|e| diagnosed_error!("{e}"))).ok_or_else(
-                || diagnosed_error!("expected 'offset' field in patch item to be a u64"),
-            )??;
+        let get_field = |key: &str| -> Result<&Value, Diagnostic> {
+            map.get(key).ok_or_else(|| diagnosed_error!("missing '{key}' field in patch item"))
+        };
 
-        let some_length = map
-            .get("length")
-            .ok_or_else(|| diagnosed_error!("missing 'length' field in patch item"))?;
-        let length =
-            some_length.as_uint().map(|r| r.map_err(|e| diagnosed_error!("{e}"))).ok_or_else(
-                || diagnosed_error!("expected 'length' field in patch item to be a u64"),
-            )??;
+        let offset = get_field("offset")?
+            .as_uint()
+            .ok_or_else(|| diagnosed_error!("expected 'offset' field in patch item to be a u64"))?
+            .map_err(|e| diagnosed_error!("{e}"))?;
 
-        let some_field_value = map
-            .get("field_value")
-            .ok_or_else(|| diagnosed_error!("missing 'field_value' field in patch item"))?;
-        let field_value = some_field_value
+        let length = get_field("length")?
+            .as_uint()
+            .ok_or_else(|| diagnosed_error!("expected 'length' field in patch item to be a u64"))?
+            .map_err(|e| diagnosed_error!("{e}"))?;
+
+        let field_value = get_field("field_value")?
             .as_string()
             .ok_or_else(|| {
                 diagnosed_error!("expected 'field_value' field in patch item to be a hex string")
             })?
             .to_string();
 
-        let some_field_type = map
-            .get("field_type")
-            .ok_or_else(|| diagnosed_error!("missing 'field_type' field in patch item"))?;
-        let field_type = some_field_type
+        let field_type = get_field("field_type")?
             .as_string()
             .ok_or_else(|| {
                 diagnosed_error!("expected 'field_type' field in patch item to be a string")
@@ -302,9 +295,7 @@ impl SurfpoolAccountUpdate {
 
             let data_bytes = if let Some(patch) = map.swap_remove("patch") {
                 let patches = patch.as_array().ok_or_else(|| {
-                    diagnosed_error!(
-            "expected 'patch' field to be a map with 'offset', 'length', and 'bytes' fields"
-        )
+                    diagnosed_error!("expected 'patch' field to be a map with 'offset', 'length', and 'bytes' fields")
                 })?;
 
                 let mut data_bytes = match data_bytes {

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -29,6 +29,8 @@ macro_rules! parse_num {
 
 #[cfg(test)]
 mod tests {
+    use solana_pubkey::pubkey;
+
     #[allow(unused_imports)]
     use super::*;
     #[test]
@@ -39,12 +41,66 @@ mod tests {
         assert_eq!(parse_num!(i16, "-32768"), vec![0, 128]);
         assert_eq!(parse_num!(u32, "4294967295"), vec![255, 255, 255, 255]);
         assert_eq!(parse_num!(i32, "-2147483648"), vec![0, 0, 0, 128]);
-        assert_eq!(parse_num!(u64, "18446744073709551615"), vec![255, 255, 255, 255, 255, 255, 255, 255]);
+        assert_eq!(
+            parse_num!(u64, "18446744073709551615"),
+            vec![255, 255, 255, 255, 255, 255, 255, 255]
+        );
         assert_eq!(parse_num!(i64, "-9223372036854775808"), vec![0, 0, 0, 0, 0, 0, 0, 128]);
         assert_eq!(parse_num!(u128, "340282366920938463463374607431768211455"), vec![255; 16]);
         assert_eq!(parse_num!(i128, "0"), vec![0; 16]);
         assert_eq!(parse_num!(f32, "3.14"), 3.14f32.to_le_bytes().to_vec());
         assert_eq!(parse_num!(f64, "3.14"), 3.14f64.to_le_bytes().to_vec());
+        Ok(())
+    }
+
+    #[test]
+    fn test_patch_account_data_from_map() -> Result<(), Diagnostic> {
+        let mut map = IndexMap::new();
+        map.insert("offset".to_string(), Value::Integer(0));
+        map.insert("length".to_string(), Value::Integer(4));
+        map.insert("field_value".to_string(), Value::String("255".to_string()));
+        map.insert("field_type".to_string(), Value::String("u32".to_string()));
+
+        let patch_data = PatchAccountData::from_map(&map)?;
+        assert_eq!(patch_data.offset, 0);
+        assert_eq!(patch_data.length, 4);
+        assert_eq!(patch_data.field_value, "255");
+        assert_eq!(patch_data.field_type, "u32");
+        Ok(())
+    }
+
+    #[test]
+    fn test_surfpool_account_update_from_map_with_patch_application() -> Result<(), Diagnostic> {
+        let mut map = IndexMap::new();
+        map.insert(
+            "public_key".to_string(),
+            SvmValue::pubkey(pubkey!("11111111111111111111111111111111").to_bytes().to_vec()),
+        );
+
+        let patch = Value::Array(Box::new(vec![
+            (Value::Object({
+                let mut m = IndexMap::new();
+                m.insert("offset".to_string(), Value::Integer(0));
+                m.insert("length".to_string(), Value::Integer(4));
+                m.insert("field_value".to_string(), Value::String("1".to_string()));
+                m.insert("field_type".to_string(), Value::String("u32".to_string()));
+                m
+            })),
+        ]));
+
+        map.insert("patch".to_string(), patch);
+
+        let auth_ctx = AuthorizationContext::empty();
+        let mut prefetched_data = HashMap::new();
+
+        prefetched_data.insert(
+            "11111111111111111111111111111111".to_string(),
+            vec![0; 8], // Original data is 8 bytes of zeros
+        );
+        let account_update =
+            SurfpoolAccountUpdate::from_map(&mut map, &auth_ctx, &prefetched_data)?;
+        assert_eq!(account_update.public_key.to_string(), "11111111111111111111111111111111");
+        assert_eq!(account_update.data, Some("0100000000000000".to_string())); // 1 in little-endian hex
         Ok(())
     }
 }

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -65,9 +65,9 @@ fn field_value_to_bytes(field_type: &str, field_value: &Value) -> Result<Vec<u8>
 fn apply_patches_raw(
     data_bytes: Option<Vec<u8>>,
     patch: &Value,
-    prefetched_data: &HashMap<String, Vec<u8>>,
+    prefetched_data: &HashMap<String, Option<Vec<u8>>>,
     public_key: &Pubkey,
-) -> Result<Vec<u8>, Diagnostic> {
+) -> Result<Option<Vec<u8>>, Diagnostic> {
     let patches = patch.as_array().ok_or_else(|| {
         diagnosed_error!(
             "expected 'patch_raw' field to be an array of maps with 'offset', 'length', 'field_value', and 'field_type' fields"
@@ -76,9 +76,21 @@ fn apply_patches_raw(
 
     let mut data_bytes = match data_bytes {
         Some(d) => d,
-        None => prefetched_data.get(&public_key.to_string()).cloned().ok_or_else(|| {
-            diagnosed_error!("account data must be provided or prefetched for patching")
-        })?,
+        None => match prefetched_data.get(&public_key.to_string()) {
+            Some(Some(d)) => d.clone(),
+            Some(None) => {
+                eprintln!(
+                    "Warning: skipping patch_raw for account {}: account does not exist on-chain",
+                    public_key
+                );
+                return Ok(None);
+            }
+            None => {
+                return Err(diagnosed_error!(
+                    "account data must be provided or prefetched for patching"
+                ));
+            }
+        },
     };
 
     for patch_item in patches.iter() {
@@ -111,7 +123,7 @@ fn apply_patches_raw(
         data_bytes[range].copy_from_slice(&bytes);
     }
 
-    Ok(data_bytes)
+    Ok(Some(data_bytes))
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -197,7 +209,7 @@ impl SurfpoolAccountUpdate {
     pub fn from_map(
         map: &mut IndexMap<String, Value>,
         auth_ctx: &AuthorizationContext,
-        prefetched_data: &HashMap<String, Vec<u8>>,
+        prefetched_data: &HashMap<String, Option<Vec<u8>>>,
     ) -> Result<Self, Diagnostic> {
         let some_public_key = map.swap_remove("public_key");
 
@@ -297,7 +309,7 @@ impl SurfpoolAccountUpdate {
                 .transpose()?;
 
             let data_bytes = if let Some(patch) = map.swap_remove("patch_raw") {
-                Some(apply_patches_raw(data_bytes, &patch, prefetched_data, &public_key)?)
+                apply_patches_raw(data_bytes, &patch, prefetched_data, &public_key)?
             } else {
                 data_bytes
             };
@@ -343,7 +355,7 @@ impl SurfpoolAccountUpdate {
     pub async fn get_accounts_data_if_needed(
         values: &ValueStore,
         rpc_client: &RpcClient,
-    ) -> Result<HashMap<String, Vec<u8>>, Diagnostic> {
+    ) -> Result<HashMap<String, Option<Vec<u8>>>, Diagnostic> {
         let account_updates = match Self::get_account_update_maps(values)? {
             None => return Ok(HashMap::new()),
             Some(maps) => maps,
@@ -384,7 +396,7 @@ impl SurfpoolAccountUpdate {
             .map_err(|e| diagnosed_error!("failed to prefetch account infos: {e}"))?
             .into_iter()
             .zip(accounts_to_fetch.iter())
-            .filter_map(|(acc, pubkey)| acc.map(|a| (pubkey.to_string(), a.data)))
+            .map(|(acc, pubkey)| (pubkey.to_string(), acc.map(|a| a.data)))
             .collect();
 
         Ok(accounts_data)
@@ -393,7 +405,7 @@ impl SurfpoolAccountUpdate {
     pub fn parse_value_store(
         values: &ValueStore,
         auth_ctx: &AuthorizationContext,
-        prefetched_data: HashMap<String, Vec<u8>>,
+        prefetched_data: HashMap<String, Option<Vec<u8>>>,
     ) -> Result<Vec<Self>, Diagnostic> {
         let mut account_update_data = match Self::get_account_update_maps(values)? {
             None => return Ok(vec![]),
@@ -525,7 +537,7 @@ mod tests {
         let auth_ctx = AuthorizationContext::empty();
         let mut prefetched_data = HashMap::new();
 
-        prefetched_data.insert(PUBKEY.to_string(), vec![0; 8]);
+        prefetched_data.insert(PUBKEY.to_string(), Some(vec![0; 8]));
         let account_update =
             SurfpoolAccountUpdate::from_map(&mut map, &auth_ctx, &prefetched_data)?;
         assert_eq!(account_update.public_key.to_string(), PUBKEY.to_string());
@@ -566,7 +578,7 @@ mod tests {
         let prefetched = HashMap::new();
         let pubkey = pubkey!("11111111111111111111111111111111");
 
-        let result = apply_patches_raw(data, &patch, &prefetched, &pubkey)?;
+        let result = apply_patches_raw(data, &patch, &prefetched, &pubkey)?.unwrap();
 
         assert_eq!(&result[0..4], &100u32.to_le_bytes());
         assert_eq!(&result[4..8], &200u32.to_le_bytes());
@@ -590,9 +602,9 @@ mod tests {
 
         let provided_data = Some(vec![0xFF; 4]);
         let mut prefetched = HashMap::new();
-        prefetched.insert(pubkey.to_string(), vec![0xAA; 4]);
+        prefetched.insert(pubkey.to_string(), Some(vec![0xAA; 4]));
 
-        let result = apply_patches_raw(provided_data, &patch, &prefetched, &pubkey)?;
+        let result = apply_patches_raw(provided_data, &patch, &prefetched, &pubkey)?.unwrap();
         assert_eq!(result[0], 42);
         assert_eq!(&result[1..4], &[0xFF; 3]);
         Ok(())
@@ -612,11 +624,51 @@ mod tests {
         let pubkey = pubkey!("11111111111111111111111111111111");
 
         let mut prefetched = HashMap::new();
-        prefetched.insert(pubkey.to_string(), vec![0xBB; 4]);
+        prefetched.insert(pubkey.to_string(), Some(vec![0xBB; 4]));
 
-        let result = apply_patches_raw(None, &patch, &prefetched, &pubkey)?;
+        let result = apply_patches_raw(None, &patch, &prefetched, &pubkey)?.unwrap();
         assert_eq!(result[0], 42);
         assert_eq!(&result[1..4], &[0xBB; 3]);
         Ok(())
+    }
+
+    #[test]
+    fn test_apply_patches_raw_skips_nonexistent_account() -> Result<(), Diagnostic> {
+        let patch = Value::array(vec![Value::object({
+            let mut m = IndexMap::new();
+            m.insert("offset".to_string(), Value::Integer(0));
+            m.insert("length".to_string(), Value::Integer(1));
+            m.insert("field_value".to_string(), Value::String("42".to_string()));
+            m.insert("field_type".to_string(), Value::String("u8".to_string()));
+            m
+        })]);
+
+        let pubkey = pubkey!("11111111111111111111111111111111");
+
+        let mut prefetched = HashMap::new();
+        prefetched.insert(pubkey.to_string(), None);
+
+        let result = apply_patches_raw(None, &patch, &prefetched, &pubkey)?;
+        assert_eq!(result, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_apply_patches_raw_errors_when_not_prefetched() {
+        let patch = Value::array(vec![Value::object({
+            let mut m = IndexMap::new();
+            m.insert("offset".to_string(), Value::Integer(0));
+            m.insert("length".to_string(), Value::Integer(1));
+            m.insert("field_value".to_string(), Value::String("42".to_string()));
+            m.insert("field_type".to_string(), Value::String("u8".to_string()));
+            m
+        })]);
+
+        let pubkey = pubkey!("11111111111111111111111111111111");
+
+        let prefetched = HashMap::new();
+
+        let result = apply_patches_raw(None, &patch, &prefetched, &pubkey);
+        assert!(result.is_err());
     }
 }

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -27,6 +27,27 @@ macro_rules! parse_num {
     }};
 }
 
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+    #[test]
+    fn test_parse_num() -> Result<(), Diagnostic> {
+        assert_eq!(parse_num!(u8, "255"), vec![255]);
+        assert_eq!(parse_num!(i8, "-128"), vec![128]);
+        assert_eq!(parse_num!(u16, "65535"), vec![255, 255]);
+        assert_eq!(parse_num!(i16, "-32768"), vec![0, 128]);
+        assert_eq!(parse_num!(u32, "4294967295"), vec![255, 255, 255, 255]);
+        assert_eq!(parse_num!(i32, "-2147483648"), vec![0, 0, 0, 128]);
+        assert_eq!(parse_num!(u64, "18446744073709551615"), vec![255, 255, 255, 255, 255, 255, 255, 255]);
+        assert_eq!(parse_num!(i64, "-9223372036854775808"), vec![0, 0, 0, 0, 0, 0, 0, 128]);
+        assert_eq!(parse_num!(u128, "340282366920938463463374607431768211455"), vec![255; 16]);
+        assert_eq!(parse_num!(i128, "0"), vec![0; 16]);
+        assert_eq!(parse_num!(f32, "3.14"), 3.14f32.to_le_bytes().to_vec());
+        assert_eq!(parse_num!(f64, "3.14"), 3.14f64.to_le_bytes().to_vec());
+        Ok(())
+    }
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchAccountData {

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -64,7 +64,7 @@ mod tests {
         let patch_data = PatchAccountData::from_map(&map)?;
         assert_eq!(patch_data.offset, 0);
         assert_eq!(patch_data.length, 4);
-        assert_eq!(patch_data.field_value, "255");
+        assert_eq!(patch_data.field_value, Value::String("255".to_string()));
         assert_eq!(patch_data.field_type, "u32");
         Ok(())
     }
@@ -73,10 +73,7 @@ mod tests {
     fn test_surfpool_account_update_from_map_with_patch_application() -> Result<(), Diagnostic> {
         let mut map = IndexMap::new();
         const PUBKEY: Pubkey = pubkey!("11111111111111111111111111111111");
-        map.insert(
-            "public_key".to_string(),
-            SvmValue::pubkey(PUBKEY.to_bytes().to_vec()),
-        );
+        map.insert("public_key".to_string(), SvmValue::pubkey(PUBKEY.to_bytes().to_vec()));
 
         let patch = Value::Array(Box::new(vec![
             (Value::Object({
@@ -106,17 +103,17 @@ mod tests {
     }
 }
 
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PatchAccountData {
     pub offset: u64,
     pub length: u64,
-    pub field_value: String,
+    pub field_value: Value,
     pub field_type: String,
 }
 
 impl PatchAccountData {
-    pub fn new(offset: u64, length: u64, field_value: String, field_type: String) -> Self {
+    pub fn new(offset: u64, length: u64, field_value: Value, field_type: String) -> Self {
         Self { offset, length, field_value, field_type }
     }
 
@@ -135,12 +132,7 @@ impl PatchAccountData {
             .ok_or_else(|| diagnosed_error!("expected 'length' field in patch item to be a u64"))?
             .map_err(|e| diagnosed_error!("{e}"))?;
 
-        let field_value = get_field("field_value")?
-            .as_string()
-            .ok_or_else(|| {
-                diagnosed_error!("expected 'field_value' field in patch item to be a hex string")
-            })?
-            .to_string();
+        let field_value = get_field("field_value")?.clone();
 
         let field_type = get_field("field_type")?
             .as_string()
@@ -320,32 +312,32 @@ impl SurfpoolAccountUpdate {
                         PatchAccountData::from_map(patch_map)?;
                     let range = offset as usize..(offset + length) as usize;
                     let bytes = match field_type.as_str() {
-                        "u8" => parse_num!(u8, &field_value),
-                        "i8" => parse_num!(i8, &field_value),
-                        "u16" => parse_num!(u16, &field_value),
-                        "i16" => parse_num!(i16, &field_value),
-                        "u32" => parse_num!(u32, &field_value),
-                        "i32" => parse_num!(i32, &field_value),
-                        "u64" => parse_num!(u64, &field_value),
-                        "i64" => parse_num!(i64, &field_value),
-                        "u128" => parse_num!(u128, &field_value),
-                        "i128" => parse_num!(i128, &field_value),
-                        "f32" => parse_num!(f32, &field_value),
-                        "f64" => parse_num!(f64, &field_value),
+                        "u8" => parse_num!(u8, &field_value.to_string()),
+                        "i8" => parse_num!(i8, &field_value.to_string()),
+                        "u16" => parse_num!(u16, &field_value.to_string()),
+                        "i16" => parse_num!(i16, &field_value.to_string()),
+                        "u32" => parse_num!(u32, &field_value.to_string()),
+                        "i32" => parse_num!(i32, &field_value.to_string()),
+                        "u64" => parse_num!(u64, &field_value.to_string()),
+                        "i64" => parse_num!(i64, &field_value.to_string()),
+                        "u128" => parse_num!(u128, &field_value.to_string()),
+                        "i128" => parse_num!(i128, &field_value.to_string()),
+                        "f32" => parse_num!(f32, &field_value.to_string()),
+                        "f64" => parse_num!(f64, &field_value.to_string()),
                         "pubkey" => {
-                            let pubkey = Pubkey::from_str(&field_value).map_err(|e| {
+                            let pubkey = Pubkey::from_str(&field_value.to_string()).map_err(|e| {
                                 diagnosed_error!("failed to parse field_value as Pubkey: {e}")
                             })?;
                             pubkey.to_bytes().to_vec()
                         }
-                        "string" => field_value.into_bytes(),
+                        "string" => field_value.to_string().into_bytes(),
                         "boolean" => {
-                            let b = bool::from_str(&field_value).map_err(|e| {
+                            let b = bool::from_str(&field_value.to_string()).map_err(|e| {
                                 diagnosed_error!("failed to parse field_value as boolean: {e}")
                             })?;
                             vec![b as u8]
                         }
-                        "buffer" => hex::decode(&field_value).map_err(|e| {
+                        "buffer" => hex::decode(&field_value.to_string()).map_err(|e| {
                             diagnosed_error!("failed to parse field_value as hex string: {e}")
                         })?,
                         _ => {

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -20,9 +20,8 @@ use crate::constants::SET_ACCOUNT;
 
 macro_rules! parse_num {
     ($type:ty, $value:expr) => {{
-        let num = <$type>::from_str($value).map_err(|e| {
-            diagnosed_error!("failed to parse value as {}: {e}", stringify!($type))
-        })?;
+        let num = <$type>::from_str($value)
+            .map_err(|e| diagnosed_error!("failed to parse value as {}: {e}", stringify!($type)))?;
         num.to_le_bytes().to_vec()
     }};
 }
@@ -147,12 +146,16 @@ impl PatchRawAccountData {
 
         let offset = get_field("offset")?
             .as_uint()
-            .ok_or_else(|| diagnosed_error!("expected 'offset' field in patch_raw block to be a u64"))?
+            .ok_or_else(|| {
+                diagnosed_error!("expected 'offset' field in patch_raw block to be a u64")
+            })?
             .map_err(|e| diagnosed_error!("{e}"))?;
 
         let length = get_field("length")?
             .as_uint()
-            .ok_or_else(|| diagnosed_error!("expected 'length' field in patch_raw block to be a u64"))?
+            .ok_or_else(|| {
+                diagnosed_error!("expected 'length' field in patch_raw block to be a u64")
+            })?
             .map_err(|e| diagnosed_error!("{e}"))?;
 
         let value = get_field("value")?.clone();

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -23,12 +23,13 @@ use crate::constants::SET_ACCOUNT;
 pub struct PatchAccountData {
     pub offset: u64,
     pub length: u64,
-    pub bytes: Vec<u8>,
+    pub bytes: String,
+    pub patch_type: String,
 }
 
 impl PatchAccountData {
-    pub fn new(offset: u64, length: u64, bytes: Vec<u8>) -> Self {
-        Self { offset, length, bytes }
+    pub fn new(offset: u64, length: u64, bytes: String, patch_type: String) -> Self {
+        Self { offset, length, bytes, patch_type }
     }
 
     pub fn from_map(map: &IndexMap<String, Value>) -> Result<Self, Diagnostic> {
@@ -55,14 +56,20 @@ impl PatchAccountData {
             .as_string()
             .ok_or_else(|| {
                 diagnosed_error!("expected 'bytes' field in patch item to be a hex string")
-            })
-            .and_then(|s| {
-                hex::decode(s).map_err(|e| {
-                    diagnosed_error!("invalid hex string in 'bytes' field of patch item: {e}")
-                })
-            })?;
+            })?
+            .to_string();
 
-        Ok(Self::new(offset, length, bytes))
+        let some_patch_type = map
+            .get("patch_type")
+            .ok_or_else(|| diagnosed_error!("missing 'patch_type' field in patch item"))?;
+        let patch_type = some_patch_type
+            .as_string()
+            .ok_or_else(|| {
+                diagnosed_error!("expected 'patch_type' field in patch item to be a string")
+            })?
+            .to_string();
+
+        Ok(Self::new(offset, length, bytes, patch_type))
     }
 }
 
@@ -231,9 +238,75 @@ impl SurfpoolAccountUpdate {
                 "expected each item in 'patch' array to be a map with 'offset', 'length', and 'bytes' fields"
             ))?;
 
-                    let PatchAccountData { offset, length, bytes } =
+                    let PatchAccountData { offset, length, bytes, patch_type } =
                         PatchAccountData::from_map(patch_map)?;
                     let range = offset as usize..(offset + length) as usize;
+                    let bytes = match patch_type.as_str() {
+                        "u8" | "i8" => {
+                            let num = u8::from_str(&bytes).map_err(|e| {
+                                diagnosed_error!("failed to parse patch bytes as u8: {e}")
+                            })?;
+                            vec![num]
+                        }
+                        "u16" | "i16" => {
+                            let num = u16::from_str(&bytes).map_err(|e| {
+                                diagnosed_error!("failed to parse patch bytes as u16: {e}")
+                            })?;
+                            num.to_be_bytes().to_vec()
+                        }
+                        "u32" | "i32" => {
+                            let num = u32::from_str(&bytes).map_err(|e| {
+                                diagnosed_error!("failed to parse patch bytes as u32: {e}")
+                            })?;
+                            num.to_be_bytes().to_vec()
+                        }
+                        "u64" | "i64" => {
+                            let num = u64::from_str(&bytes).map_err(|e| {
+                                diagnosed_error!("failed to parse patch bytes as u64: {e}")
+                            })?;
+                            num.to_be_bytes().to_vec()
+                        }
+                        "u128" | "i128" => {
+                            let num = u128::from_str(&bytes).map_err(|e| {
+                                diagnosed_error!("failed to parse patch bytes as u128: {e}")
+                            })?;
+                            num.to_be_bytes().to_vec()
+                        }
+                        "f32" => {
+                            let num = f32::from_str(&bytes).map_err(|e| {
+                                diagnosed_error!("failed to parse patch bytes as f32: {e}")
+                            })?;
+                            num.to_be_bytes().to_vec()
+                        }
+                        "f64" => {
+                            let num = f64::from_str(&bytes).map_err(|e| {
+                                diagnosed_error!("failed to parse patch bytes as f64: {e}")
+                            })?;
+                            num.to_be_bytes().to_vec()
+                        }
+                        "pubkey" => {
+                            let pubkey =
+                                Pubkey::from_str(&bytes).map_err(|e| {
+                                    diagnosed_error!("failed to parse patch bytes as Pubkey: {e}")
+                                })?;
+                            pubkey.to_bytes().to_vec()
+                        }
+                        "string" => bytes.into_bytes(),
+                        "boolean" => {
+                            let b = bool::from_str(&bytes).map_err(|e| {
+                                diagnosed_error!("failed to parse patch bytes as boolean: {e}")
+                            })?;
+                            vec![b as u8]
+                        }
+                        "buffer" => hex::decode(&bytes).map_err(|e| {
+                            diagnosed_error!("failed to parse patch bytes as hex string: {e}")
+                        })?,
+                        _ => {
+                            return Err(diagnosed_error!(
+                                "invalid 'patch_type' field in patch item: must be one of 'u8', 'i8', 'u16', 'i16', 'u32', 'i32', 'u64', 'i64', 'u128', 'i128', 'f32', 'f64', 'pubkey', 'string', 'boolean', or 'buffer'"
+                            ))
+                        }
+                    };
                     data_bytes[range].copy_from_slice(&bytes);
                 }
 

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -27,6 +27,7 @@ macro_rules! parse_num {
     }};
 }
 
+#[cfg(test)]
 mod tests {
     #[allow(unused_imports)]
     use super::*;

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -342,12 +342,28 @@ impl SurfpoolAccountUpdate {
                         })?,
                         _ => {
                             return Err(diagnosed_error!(
-                                "invalid 'patch_type' field in patch item: must be one of \
+                                "invalid 'field_type' field in patch item: must be one of \
                                 'u8', 'i8', 'u16', 'i16', 'u32', 'i32', 'u64', 'i64', \
                                 'u128', 'i128', 'f32', 'f64', 'pubkey', 'string', 'boolean', or 'buffer'"
                             ))
                         }
                     };
+                    if bytes.len() != length as usize {
+                        return Err(diagnosed_error!(
+                            "patch field_type '{}' produced {} bytes, but 'length' was set to {}",
+                            field_type,
+                            bytes.len(),
+                            length
+                        ));
+                    }
+                    if (offset + length) as usize > data_bytes.len() {
+                        return Err(diagnosed_error!(
+                            "patch range {}..{} exceeds account data length ({})",
+                            offset,
+                            offset + length,
+                            data_bytes.len()
+                        ));
+                    }
                     data_bytes[range].copy_from_slice(&bytes);
                 }
 

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -302,7 +302,7 @@ impl SurfpoolAccountUpdate {
                 data_bytes
             };
 
-            let data = data_bytes.map(|d| hex::encode(d));
+            let data = data_bytes.map(hex::encode);
 
             if lamports.is_none()
                 && data.is_none()

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -70,7 +70,7 @@ fn apply_patches_raw(
 ) -> Result<Option<Vec<u8>>, Diagnostic> {
     let patches = patch.as_array().ok_or_else(|| {
         diagnosed_error!(
-            "expected 'patch_raw' field to be an array of maps with 'offset', 'length', 'field_value', and 'field_type' fields"
+            "expected 'patch_raw' to contain maps with 'offset', 'length', 'field_value', and 'field_type' fields"
         )
     })?;
 
@@ -96,7 +96,7 @@ fn apply_patches_raw(
     for patch_item in patches.iter() {
         let patch_map = patch_item.as_object().ok_or_else(|| {
             diagnosed_error!(
-                "expected each item in 'patch_raw' array to be a map with 'offset', 'length', 'field_value', and 'field_type' fields"
+                "expected each 'patch_raw' item to be a map with 'offset', 'length', 'field_value', and 'field_type' fields"
             )
         })?;
 

--- a/addons/svm/types/src/lib.rs
+++ b/addons/svm/types/src/lib.rs
@@ -765,29 +765,29 @@ lazy_static! {
         }
     };
 
-    pub static ref SET_ACCOUNT_PATCH: Type = define_documented_arbitrary_map_type! {
+    pub static ref SET_ACCOUNT_PATCH: Type = define_strict_map_type! {
         offset: {
             documentation: "The offset at which the patch should be applied.",
             typing: Type::integer(),
-            optional: true,
+            optional: false,
             tainting: true
         },
         length: {
             documentation: "The length of the patch.",
             typing: Type::integer(),
-            optional: true,
+            optional: false,
             tainting: true
         },
         field_value: {
             documentation: "The bytes of the patch.",
             typing: Type::string(),
-            optional: true,
+            optional: false,
             tainting: true
         },
         field_type: {
             documentation: "The type of the field being patched. This is used to determine how to apply the patch. Valid values are 'u8', 'u16', 'u32', 'u64', 'u128', 'i8', 'i16', 'i32', 'i64', 'i128', 'f32', 'f64', 'pubkey', 'string', 'boolean', or 'buffer'.",
             typing: Type::string(),
-            optional: true,
+            optional: false,
             tainting: true
         }
     };

--- a/addons/svm/types/src/lib.rs
+++ b/addons/svm/types/src/lib.rs
@@ -779,7 +779,7 @@ lazy_static! {
             tainting: true
         },
         field_value: {
-            documentation: "The bytes of the patch.",
+            documentation: "The value to write at the patch offset, interpreted according to `field_type`.",
             typing: Type::string(),
             optional: false,
             tainting: true

--- a/addons/svm/types/src/lib.rs
+++ b/addons/svm/types/src/lib.rs
@@ -837,7 +837,7 @@ lazy_static! {
         },
         patch_raw: {
             documentation: "A raw patch to apply to the account's existing data. Each item specifies an offset, length, field_value, and field_type to determine which bytes of the account data to replace.",
-            typing: Type::array(SET_ACCOUNT_PATCH_RAW.clone()),
+            typing: SET_ACCOUNT_PATCH_RAW.clone(),
             optional: true,
             tainting: true
         }

--- a/addons/svm/types/src/lib.rs
+++ b/addons/svm/types/src/lib.rs
@@ -783,6 +783,12 @@ lazy_static! {
             typing: Type::string(),
             optional: true,
             tainting: true
+        },
+        field_type: {
+            documentation: "The type of the field being patched. This is used to determine how to apply the patch. Valid values are 'u8', 'u16', 'u32', 'u64', 'u128', 'i8', 'i16', 'i32', 'i64', 'i128', 'f32', 'f64', 'pubkey', 'string', 'boolean', or 'buffer'.",
+            typing: Type::string(),
+            optional: true,
+            tainting: true
         }
     };
 

--- a/addons/svm/types/src/lib.rs
+++ b/addons/svm/types/src/lib.rs
@@ -765,7 +765,7 @@ lazy_static! {
         }
     };
 
-    pub static ref SET_ACCOUNT_PATCH: Type = define_strict_map_type! {
+    pub static ref SET_ACCOUNT_PATCH_RAW: Type = define_strict_map_type! {
         offset: {
             documentation: "The offset at which the patch should be applied.",
             typing: Type::integer(),
@@ -835,9 +835,9 @@ lazy_static! {
             optional: true,
             tainting: true
         },
-        patch: {
-            documentation: "A patch to apply to the account's existing data. If provided, the offset and length will determine which bytes of the account data to replace with the provided bytes.",
-            typing: Type::array(SET_ACCOUNT_PATCH.clone()),
+        patch_raw: {
+            documentation: "A raw patch to apply to the account's existing data. Each item specifies an offset, length, field_value, and field_type to determine which bytes of the account data to replace.",
+            typing: Type::array(SET_ACCOUNT_PATCH_RAW.clone()),
             optional: true,
             tainting: true
         }

--- a/addons/svm/types/src/lib.rs
+++ b/addons/svm/types/src/lib.rs
@@ -765,6 +765,27 @@ lazy_static! {
         }
     };
 
+    pub static ref SET_ACCOUNT_PATCH: Type = define_documented_arbitrary_map_type! {
+        offset: {
+            documentation: "The offset at which the patch should be applied.",
+            typing: Type::integer(),
+            optional: true,
+            tainting: true
+        },
+        length: {
+            documentation: "The length of the patch.",
+            typing: Type::integer(),
+            optional: true,
+            tainting: true
+        },
+        bytes: {
+            documentation: "The bytes of the patch.",
+            typing: Type::string(),
+            optional: true,
+            tainting: true
+        }
+    };
+
     pub static ref SET_ACCOUNT_MAP: Type = define_strict_map_type! {
         public_key: {
             documentation: "The public key of the account to set.",
@@ -805,6 +826,12 @@ lazy_static! {
         account_path: {
             documentation: "The path to a JSON file containing the account data to set. If provided, all other fields.",
             typing: Type::string(),
+            optional: true,
+            tainting: true
+        },
+        patch: {
+            documentation: "A patch to apply to the account's existing data. If provided, the offset and length will determine which bytes of the account data to replace with the provided bytes.",
+            typing: Type::array(SET_ACCOUNT_PATCH.clone()),
             optional: true,
             tainting: true
         }

--- a/addons/svm/types/src/lib.rs
+++ b/addons/svm/types/src/lib.rs
@@ -778,7 +778,7 @@ lazy_static! {
             optional: true,
             tainting: true
         },
-        bytes: {
+        field_value: {
             documentation: "The bytes of the patch.",
             typing: Type::string(),
             optional: true,

--- a/addons/svm/types/src/lib.rs
+++ b/addons/svm/types/src/lib.rs
@@ -778,13 +778,13 @@ lazy_static! {
             optional: false,
             tainting: true
         },
-        field_value: {
-            documentation: "The value to write at the patch offset, interpreted according to `field_type`.",
+        value: {
+            documentation: "The value to write at the patch offset, interpreted according to `type`.",
             typing: Type::string(),
             optional: false,
             tainting: true
         },
-        field_type: {
+        r#type: {
             documentation: "The type of the field being patched. This is used to determine how to apply the patch. Valid values are 'u8', 'u16', 'u32', 'u64', 'u128', 'i8', 'i16', 'i32', 'i64', 'i128', 'f32', 'f64', 'pubkey', 'string', 'boolean', or 'buffer'.",
             typing: Type::string(),
             optional: false,
@@ -836,7 +836,7 @@ lazy_static! {
             tainting: true
         },
         patch_raw: {
-            documentation: "A raw patch to apply to the account's existing data. Each item specifies an offset, length, field_value, and field_type to determine which bytes of the account data to replace.",
+            documentation: "A raw patch to apply to the account's existing data. Each block specifies an offset, length, value, and type to determine which bytes of the account data to replace.",
             typing: SET_ACCOUNT_PATCH_RAW.clone(),
             optional: true,
             tainting: true

--- a/addons/svm/types/src/lib.rs
+++ b/addons/svm/types/src/lib.rs
@@ -784,7 +784,7 @@ lazy_static! {
             optional: false,
             tainting: true
         },
-        r#type: {
+        type: {
             documentation: "The type of the field being patched. This is used to determine how to apply the patch. Valid values are 'u8', 'u16', 'u32', 'u64', 'u128', 'i8', 'i16', 'i32', 'i64', 'i128', 'f32', 'f64', 'pubkey', 'string', 'boolean', or 'buffer'.",
             typing: Type::string(),
             optional: false,


### PR DESCRIPTION
Closes #401

> **Note:** This is one of two PRs that together address #401. Splitting into separate branches makes each change easier to review in isolation.

## Overview

This PR adds support for raw byte-level patching of account data during the `setup_surfnet` `set_account` setup phase. This allows precise, typed mutations to specific offsets within an account's data; useful when you need to update fields like public keys or numeric values at known byte positions.

## Example Usage

```hcl
action "setup_surfnet" "svm::setup_surfnet" {
  set_account {
    public_key = "3BznENHP5KkRikLZqCLGLTaVGcDBsWDTLjSCbHZD2qTA"
    patch_raw = [
      {
        offset      = 8
        length      = 32
        field_value = "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo"
        field_type  = "pubkey"
      },
      {
        offset      = 7960
        length      = 32
        field_value = "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo"
        field_type  = "pubkey"
      },
      {
        offset      = 7936
        length      = 8
        field_value = 5
        field_type  = "u64"
      }
    ]
  }
}
```

## Changes

### New type: `SET_ACCOUNT_PATCH_RAW` (`addons/svm/types/src/lib.rs`)
- Defines a patch descriptor with `offset`, `length`, `field_value`, and `field_type` fields
- Enables granular, typed mutations at arbitrary byte offsets within account data
- Supported `field_type` values include `pubkey`, `u64`, and others (see known limitation below)

### Extended type: `SET_ACCOUNT_MAP`
- Added an optional `patch_raw` field accepting an array of `SET_ACCOUNT_PATCH_RAW` objects
- Multiple patches can be applied to a single account in one update

### Updated: `SetupSurfpool` command
- Pre-fetches existing account data when `patch_raw` is present, providing the required context for mutations
- Passes fetched data to `SurfpoolAccountUpdate::parse_value_store` so patches are applied correctly

## Known Limitation

The typing of `field_value` is currently loose: it accepts a `String`, `Int`, `Bytes`, `Pubkey`, etc., but this is not yet well-reflected in the documentation or type definitions. A follow-up issue should be opened to tighten the type signature and improve the developer experience here.

## How to test it:

I tested it/played around it outside of rust tests, using surfpool: Please view this [branch](https://github.com/solana-foundation/surfpool/commit/ae909fecaf4e56b18630b64950437d2a8de78c42) of my surfpool fork to see how I used it. In this branch I use a Meteora DLMM account and I switch some data, then I later see it on a TS script: 