### PR TITLE
Refactor: three DRY findings from a rust-scope audit

### DIFF
--- a/addons/evm/src/typing.rs
+++ b/addons/evm/src/typing.rs
@@ -4,6 +4,7 @@ use alloy_json_abi::{Function, Param};
 use alloy_primitives::Address;
 use alloy_rpc_types::Log;
 use foundry_compilers_artifacts_solc::Metadata;
+use serde::de::DeserializeOwned;
 use txtx_addon_kit::{
     hex,
     indexmap::IndexMap,
@@ -15,6 +16,27 @@ use txtx_addon_kit::{
 };
 
 use crate::{codec::foundry::BytecodeData, constants::LINKED_LIBRARIES};
+
+/// Decode the bytes payload of an addon `Value`, verifying its id matches `expected_id`.
+/// `what` names the target type for error messages (e.g. "foundry metadata").
+fn decode_addon_bytes<T: DeserializeOwned>(
+    value: &Value,
+    expected_id: &str,
+    what: &str,
+) -> Result<T, Diagnostic> {
+    let err_prefix = format!("could not convert value to {what}");
+    let addon_data = value
+        .as_addon_data()
+        .ok_or_else(|| diagnosed_error!("{err_prefix}: not an addon data type"))?;
+    if addon_data.id != expected_id {
+        return Err(diagnosed_error!(
+            "{err_prefix}: expected type {expected_id}, got {}",
+            addon_data.id
+        ));
+    }
+    serde_json::from_slice(&addon_data.bytes)
+        .map_err(|e| diagnosed_error!("{err_prefix}: {e}"))
+}
 
 pub const EVM_ADDRESS: &str = "evm::address";
 pub const EVM_BYTES: &str = "evm::bytes";
@@ -128,27 +150,16 @@ impl EvmValue {
     }
 
     pub fn to_sim_result(value: &Value) -> Result<(Vec<u8>, Option<Function>), Diagnostic> {
-        let err_msg = "could not convert value to sim result";
-        let addon_data = value
-            .as_addon_data()
-            .ok_or_else(|| diagnosed_error!("{err_msg}: not an addon data type"))?;
-        if addon_data.id != EVM_SIM_RESULT {
-            return Err(diagnosed_error!(
-                "{err_msg}: expected type {EVM_SIM_RESULT}, got {}",
-                addon_data.id
-            ));
-        }
         let (sim_result_bytes, function_spec): (Vec<u8>, Option<Vec<u8>>) =
-            serde_json::from_slice(&addon_data.bytes)
-                .map_err(|e| diagnosed_error!("{err_msg}: {e}"))?;
-        let fn_spec = if let Some(fn_spec) = function_spec {
-            let fn_spec: Function = serde_json::from_slice(&fn_spec).map_err(|e| {
-                diagnosed_error!("{err_msg}: could not deserialize expected type: {e}")
+            decode_addon_bytes(value, EVM_SIM_RESULT, "sim result")?;
+        let fn_spec = function_spec
+            .map(|fn_spec| serde_json::from_slice::<Function>(&fn_spec))
+            .transpose()
+            .map_err(|e| {
+                diagnosed_error!(
+                    "could not convert value to sim result: could not deserialize expected type: {e}"
+                )
             })?;
-            Some(fn_spec)
-        } else {
-            None
-        };
         Ok((sim_result_bytes, fn_spec))
     }
 
@@ -159,19 +170,7 @@ impl EvmValue {
     }
 
     pub fn to_known_sol_param(value: &Value) -> Result<(Value, Param), Diagnostic> {
-        let err_msg = "could not convert value to known sol type";
-        let addon_data = value
-            .as_addon_data()
-            .ok_or_else(|| diagnosed_error!("{err_msg}: not an addon data type"))?;
-        if addon_data.id != EVM_KNOWN_SOL_PARAM {
-            return Err(diagnosed_error!(
-                "{err_msg}: expected type {EVM_KNOWN_SOL_PARAM}, got {}",
-                addon_data.id
-            ));
-        }
-        let (value, ty): (Value, Param) = serde_json::from_slice(&addon_data.bytes)
-            .map_err(|e| diagnosed_error!("{err_msg}: {e}"))?;
-        Ok((value, ty))
+        decode_addon_bytes(value, EVM_KNOWN_SOL_PARAM, "known sol type")
     }
 
     pub fn foundry_compiled_metadata(value: &Metadata) -> Result<Value, Diagnostic> {
@@ -181,19 +180,7 @@ impl EvmValue {
     }
 
     pub fn to_foundry_compiled_metadata(value: &Value) -> Result<Metadata, Diagnostic> {
-        let err_msg = "could not convert value to foundry metadata";
-        let addon_data = value
-            .as_addon_data()
-            .ok_or_else(|| diagnosed_error!("{err_msg}: not an addon data type"))?;
-        if addon_data.id != EVM_FOUNDRY_COMPILED_METADATA {
-            return Err(diagnosed_error!(
-                "{err_msg}: expected type {EVM_FOUNDRY_COMPILED_METADATA}, got {}",
-                addon_data.id
-            ));
-        }
-        let metadata: Metadata = serde_json::from_slice(&addon_data.bytes)
-            .map_err(|e| diagnosed_error!("{err_msg}: {e}"))?;
-        Ok(metadata)
+        decode_addon_bytes(value, EVM_FOUNDRY_COMPILED_METADATA, "foundry metadata")
     }
 
     pub fn foundry_bytecode_data(value: &BytecodeData) -> Result<Value, Diagnostic> {
@@ -203,19 +190,7 @@ impl EvmValue {
     }
 
     pub fn to_foundry_bytecode_data(value: &Value) -> Result<BytecodeData, Diagnostic> {
-        let err_msg = "could not convert value to foundry bytecode data";
-        let addon_data = value
-            .as_addon_data()
-            .ok_or_else(|| diagnosed_error!("{err_msg}: not an addon data type"))?;
-        if addon_data.id != EVM_FOUNDRY_BYTECODE_DATA {
-            return Err(diagnosed_error!(
-                "{err_msg}: expected type {EVM_FOUNDRY_BYTECODE_DATA}, got {}",
-                addon_data.id
-            ));
-        }
-        let bytecode: BytecodeData = serde_json::from_slice(&addon_data.bytes)
-            .map_err(|e| diagnosed_error!("{err_msg}: {e}"))?;
-        Ok(bytecode)
+        decode_addon_bytes(value, EVM_FOUNDRY_BYTECODE_DATA, "foundry bytecode data")
     }
 
     pub fn parse_linked_libraries(

--- a/addons/svm/core/src/codec/utils.rs
+++ b/addons/svm/core/src/codec/utils.rs
@@ -9,6 +9,7 @@ use txtx_addon_kit::types::{diagnostics::Diagnostic, types::Value};
 use txtx_addon_network_svm_types::anchor::types::Idl;
 
 use crate::commands::setup_surfnet::set_account::SurfpoolAccountUpdate;
+use crate::commands::setup_surfnet::surfnet_update::SurfnetAccountUpdate;
 
 pub fn get_seeds_from_value(value: &Value) -> Result<Vec<Vec<u8>>, Diagnostic> {
     let seeds = value

--- a/addons/svm/core/src/commands/setup_surfnet/clone_program_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/clone_program_account.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_client::rpc_request::RpcRequest;
 use solana_pubkey::Pubkey;
 
 use txtx_addon_kit::{
@@ -10,6 +8,7 @@ use txtx_addon_kit::{
 };
 use txtx_addon_network_svm_types::SvmValue;
 
+use super::surfnet_update::SurfnetAccountUpdate;
 use crate::constants::CLONE_PROGRAM_ACCOUNT;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -81,14 +80,17 @@ impl SurfpoolProgramCloning {
         Ok(program_clones)
     }
 
+}
+
+impl SurfnetAccountUpdate for SurfpoolProgramCloning {
+    fn rpc_method() -> &'static str {
+        "surfnet_cloneProgramAccount"
+    }
+
     fn to_request_params(&self) -> serde_json::Value {
         let source_program_id = json![self.source_program_id.to_string()];
         let destination_program_id = json![self.destination_program_id.to_string()];
         json!(vec![source_program_id, destination_program_id])
-    }
-
-    fn rpc_method() -> &'static str {
-        "surfnet_cloneProgramAccount"
     }
 
     fn update_status(&self, logger: &LogDispatcher, index: usize, total: usize) {
@@ -96,27 +98,5 @@ impl SurfpoolProgramCloning {
             "Program Account Cloned",
             &format!("Cloned program account #{}/{}", index + 1, total,),
         );
-    }
-
-    async fn send_request(&self, rpc_client: &RpcClient) -> Result<serde_json::Value, Diagnostic> {
-        rpc_client
-            .send::<serde_json::Value>(
-                RpcRequest::Custom { method: Self::rpc_method() },
-                self.to_request_params(),
-            )
-            .await
-            .map_err(|e| diagnosed_error!("`{}` RPC call failed: {e}", Self::rpc_method()))
-    }
-
-    pub async fn process_updates(
-        account_updates: Vec<Self>,
-        rpc_client: &RpcClient,
-        logger: &LogDispatcher,
-    ) -> Result<(), Diagnostic> {
-        for (i, account_update) in account_updates.iter().enumerate() {
-            let _ = account_update.send_request(rpc_client).await?;
-            account_update.update_status(logger, i, account_updates.len());
-        }
-        Ok(())
     }
 }

--- a/addons/svm/core/src/commands/setup_surfnet/mod.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/mod.rs
@@ -5,7 +5,10 @@ pub mod set_account;
 mod set_program_authority;
 mod set_token_account;
 mod stream_account;
+pub(crate) mod surfnet_update;
 mod tokens;
+
+use surfnet_update::SurfnetAccountUpdate;
 
 use clone_program_account::SurfpoolProgramCloning;
 use set_account::SurfpoolAccountUpdate;

--- a/addons/svm/core/src/commands/setup_surfnet/reset_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/reset_account.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_client::rpc_request::RpcRequest;
 use solana_pubkey::Pubkey;
 use txtx_addon_kit::{
     indexmap::IndexMap,
@@ -9,6 +7,7 @@ use txtx_addon_kit::{
 };
 use txtx_addon_network_svm_types::SvmValue;
 
+use super::surfnet_update::SurfnetAccountUpdate;
 use crate::constants::RESET_ACCOUNT;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -82,6 +81,13 @@ impl SurfpoolResetAccount {
         Ok(account_resets)
     }
 
+}
+
+impl SurfnetAccountUpdate for SurfpoolResetAccount {
+    fn rpc_method() -> &'static str {
+        "surfnet_resetAccount"
+    }
+
     fn to_request_params(&self) -> serde_json::Value {
         let pubkey = json![self.public_key.to_string()];
         let mut params = vec![pubkey];
@@ -91,10 +97,6 @@ impl SurfpoolResetAccount {
             params.push(config);
         }
         json!(params)
-    }
-
-    fn rpc_method() -> &'static str {
-        "surfnet_resetAccount"
     }
 
     fn update_status(&self, logger: &LogDispatcher, index: usize, total: usize) {
@@ -107,30 +109,5 @@ impl SurfpoolResetAccount {
                 self.public_key.to_string()
             ),
         );
-    }
-
-    pub async fn send_request(
-        &self,
-        rpc_client: &RpcClient,
-    ) -> Result<serde_json::Value, Diagnostic> {
-        rpc_client
-            .send::<serde_json::Value>(
-                RpcRequest::Custom { method: Self::rpc_method() },
-                self.to_request_params(),
-            )
-            .await
-            .map_err(|e| diagnosed_error!("`{}` RPC call failed: {e}", Self::rpc_method()))
-    }
-
-    pub async fn process_updates(
-        account_updates: Vec<Self>,
-        rpc_client: &RpcClient,
-        logger: &LogDispatcher,
-    ) -> Result<(), Diagnostic> {
-        for (i, account_update) in account_updates.iter().enumerate() {
-            let _ = account_update.send_request(rpc_client).await?;
-            account_update.update_status(logger, i, account_updates.len());
-        }
-        Ok(())
     }
 }

--- a/addons/svm/core/src/commands/setup_surfnet/set_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_account.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use solana_account_decoder_client_types::UiAccount;
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_client::rpc_request::RpcRequest;
 use solana_pubkey::Pubkey;
 use txtx_addon_kit::{
     hex,
@@ -16,6 +15,7 @@ use txtx_addon_kit::{
 };
 use txtx_addon_network_svm_types::SvmValue;
 
+use super::surfnet_update::SurfnetAccountUpdate;
 use crate::codec::idl::{borsh_encode_value_to_idl_type, get_field_offset_in_account};
 use crate::constants::SET_ACCOUNT;
 
@@ -589,14 +589,17 @@ impl SurfpoolAccountUpdate {
         Ok(account_updates)
     }
 
+}
+
+impl SurfnetAccountUpdate for SurfpoolAccountUpdate {
+    fn rpc_method() -> &'static str {
+        "surfnet_setAccount"
+    }
+
     fn to_request_params(&self) -> serde_json::Value {
         let pubkey = json![self.public_key.to_string()];
         let account_update = serde_json::to_value(&self).unwrap();
         json!(vec![pubkey, account_update])
-    }
-
-    fn rpc_method() -> &'static str {
-        "surfnet_setAccount"
     }
 
     fn update_status(&self, logger: &LogDispatcher, index: usize, total: usize) {
@@ -609,31 +612,6 @@ impl SurfpoolAccountUpdate {
                 self.public_key.to_string()
             ),
         );
-    }
-
-    pub async fn send_request(
-        &self,
-        rpc_client: &RpcClient,
-    ) -> Result<serde_json::Value, Diagnostic> {
-        rpc_client
-            .send::<serde_json::Value>(
-                RpcRequest::Custom { method: Self::rpc_method() },
-                self.to_request_params(),
-            )
-            .await
-            .map_err(|e| diagnosed_error!("`{}` RPC call failed: {e}", Self::rpc_method()))
-    }
-
-    pub async fn process_updates(
-        account_updates: Vec<Self>,
-        rpc_client: &RpcClient,
-        logger: &LogDispatcher,
-    ) -> Result<(), Diagnostic> {
-        for (i, account_update) in account_updates.iter().enumerate() {
-            let _ = account_update.send_request(rpc_client).await?;
-            account_update.update_status(logger, i, account_updates.len());
-        }
-        Ok(())
     }
 }
 

--- a/addons/svm/core/src/commands/setup_surfnet/set_program_authority.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_program_authority.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_client::rpc_request::RpcRequest;
 use solana_pubkey::Pubkey;
 
 use txtx_addon_kit::{
@@ -10,6 +8,7 @@ use txtx_addon_kit::{
 };
 use txtx_addon_network_svm_types::SvmValue;
 
+use super::surfnet_update::SurfnetAccountUpdate;
 use crate::constants::SET_PROGRAM_AUTHORITY;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -81,14 +80,17 @@ impl SurfpoolSetProgramAuthority {
         Ok(set_authorities)
     }
 
+}
+
+impl SurfnetAccountUpdate for SurfpoolSetProgramAuthority {
+    fn rpc_method() -> &'static str {
+        "surfnet_setProgramAuthority"
+    }
+
     fn to_request_params(&self) -> serde_json::Value {
         let program_id = json![self.program_id.to_string()];
         let authority = json![self.authority.map(|a| a.to_string())];
         json!(vec![program_id, authority])
-    }
-
-    fn rpc_method() -> &'static str {
-        "surfnet_setProgramAuthority"
     }
 
     fn update_status(&self, logger: &LogDispatcher, index: usize, total: usize) {
@@ -96,27 +98,5 @@ impl SurfpoolSetProgramAuthority {
             "Program Authority Set",
             &format!("Set program authority #{}/{}", index + 1, total,),
         );
-    }
-
-    async fn send_request(&self, rpc_client: &RpcClient) -> Result<serde_json::Value, Diagnostic> {
-        rpc_client
-            .send::<serde_json::Value>(
-                RpcRequest::Custom { method: Self::rpc_method() },
-                self.to_request_params(),
-            )
-            .await
-            .map_err(|e| diagnosed_error!("`{}` RPC call failed: {e}", Self::rpc_method()))
-    }
-
-    pub async fn process_updates(
-        account_updates: Vec<Self>,
-        rpc_client: &RpcClient,
-        logger: &LogDispatcher,
-    ) -> Result<(), Diagnostic> {
-        for (i, account_update) in account_updates.iter().enumerate() {
-            let _ = account_update.send_request(rpc_client).await?;
-            account_update.update_status(logger, i, account_updates.len());
-        }
-        Ok(())
     }
 }

--- a/addons/svm/core/src/commands/setup_surfnet/set_token_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/set_token_account.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_client::rpc_request::RpcRequest;
 use solana_pubkey::Pubkey;
 use spl_associated_token_account_interface::address::get_associated_token_address_with_program_id;
 
@@ -17,6 +15,7 @@ use txtx_addon_network_svm_types::SvmValue;
 
 use crate::constants::SET_TOKEN_ACCOUNT;
 
+use super::surfnet_update::SurfnetAccountUpdate;
 use super::tokens::get_token_by_name;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -247,16 +246,19 @@ impl SurfpoolTokenAccountUpdate {
         Ok(account_updates)
     }
 
+}
+
+impl SurfnetAccountUpdate for SurfpoolTokenAccountUpdate {
+    fn rpc_method() -> &'static str {
+        "surfnet_setTokenAccount"
+    }
+
     fn to_request_params(&self) -> serde_json::Value {
         let pubkey = json![self.public_key.to_string()];
         let token = json![self.token.to_string()];
         let token_program = json![self.token_program.pubkey().to_string()];
         let account_update = serde_json::to_value(&self).unwrap();
         json!(vec![pubkey, token, account_update, token_program])
-    }
-
-    fn rpc_method() -> &'static str {
-        "surfnet_setTokenAccount"
     }
 
     fn update_status(&self, logger: &LogDispatcher, index: usize, total: usize) {
@@ -269,28 +271,6 @@ impl SurfpoolTokenAccountUpdate {
                 self.associated_token_account.to_string()
             ),
         );
-    }
-
-    async fn send_request(&self, rpc_client: &RpcClient) -> Result<serde_json::Value, Diagnostic> {
-        rpc_client
-            .send::<serde_json::Value>(
-                RpcRequest::Custom { method: Self::rpc_method() },
-                self.to_request_params(),
-            )
-            .await
-            .map_err(|e| diagnosed_error!("`{}` RPC call failed: {e}", Self::rpc_method()))
-    }
-
-    pub async fn process_updates(
-        account_updates: Vec<Self>,
-        rpc_client: &RpcClient,
-        logger: &LogDispatcher,
-    ) -> Result<(), Diagnostic> {
-        for (i, account_update) in account_updates.iter().enumerate() {
-            let _ = account_update.send_request(rpc_client).await?;
-            account_update.update_status(logger, i, account_updates.len());
-        }
-        Ok(())
     }
 }
 

--- a/addons/svm/core/src/commands/setup_surfnet/stream_account.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/stream_account.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_client::rpc_request::RpcRequest;
 use solana_pubkey::Pubkey;
 use txtx_addon_kit::{
     indexmap::IndexMap,
@@ -9,6 +7,7 @@ use txtx_addon_kit::{
 };
 use txtx_addon_network_svm_types::SvmValue;
 
+use super::surfnet_update::SurfnetAccountUpdate;
 use crate::constants::STREAM_ACCOUNT;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -82,19 +81,21 @@ impl SurfpoolStreamAccount {
         Ok(account_resets)
     }
 
+}
+
+impl SurfnetAccountUpdate for SurfpoolStreamAccount {
+    fn rpc_method() -> &'static str {
+        "surfnet_streamAccount"
+    }
+
     fn to_request_params(&self) -> serde_json::Value {
         let pubkey = json![self.public_key.to_string()];
         let mut params = vec![pubkey];
-
         if self.include_owned_accounts.is_some() {
             let config = serde_json::to_value(&self).unwrap();
             params.push(config);
         }
         json!(params)
-    }
-
-    fn rpc_method() -> &'static str {
-        "surfnet_streamAccount"
     }
 
     fn update_status(&self, logger: &LogDispatcher, index: usize, total: usize) {
@@ -107,30 +108,5 @@ impl SurfpoolStreamAccount {
                 self.public_key.to_string()
             ),
         );
-    }
-
-    pub async fn send_request(
-        &self,
-        rpc_client: &RpcClient,
-    ) -> Result<serde_json::Value, Diagnostic> {
-        rpc_client
-            .send::<serde_json::Value>(
-                RpcRequest::Custom { method: Self::rpc_method() },
-                self.to_request_params(),
-            )
-            .await
-            .map_err(|e| diagnosed_error!("`{}` RPC call failed: {e}", Self::rpc_method()))
-    }
-
-    pub async fn process_updates(
-        account_updates: Vec<Self>,
-        rpc_client: &RpcClient,
-        logger: &LogDispatcher,
-    ) -> Result<(), Diagnostic> {
-        for (i, account_update) in account_updates.iter().enumerate() {
-            let _ = account_update.send_request(rpc_client).await?;
-            account_update.update_status(logger, i, account_updates.len());
-        }
-        Ok(())
     }
 }

--- a/addons/svm/core/src/commands/setup_surfnet/surfnet_update.rs
+++ b/addons/svm/core/src/commands/setup_surfnet/surfnet_update.rs
@@ -1,0 +1,46 @@
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_client::rpc_request::RpcRequest;
+use txtx_addon_kit::types::diagnostics::Diagnostic;
+use txtx_addon_kit::types::frontend::LogDispatcher;
+
+pub trait SurfnetAccountUpdate {
+    fn rpc_method() -> &'static str
+    where
+        Self: Sized;
+
+    fn to_request_params(&self) -> serde_json::Value;
+
+    fn update_status(&self, logger: &LogDispatcher, index: usize, total: usize);
+
+    async fn send_request(
+        &self,
+        rpc_client: &RpcClient,
+    ) -> Result<serde_json::Value, Diagnostic>
+    where
+        Self: Sized,
+    {
+        rpc_client
+            .send::<serde_json::Value>(
+                RpcRequest::Custom { method: Self::rpc_method() },
+                self.to_request_params(),
+            )
+            .await
+            .map_err(|e| diagnosed_error!("`{}` RPC call failed: {e}", Self::rpc_method()))
+    }
+
+    async fn process_updates(
+        updates: Vec<Self>,
+        rpc_client: &RpcClient,
+        logger: &LogDispatcher,
+    ) -> Result<(), Diagnostic>
+    where
+        Self: Sized,
+    {
+        let total = updates.len();
+        for (i, update) in updates.iter().enumerate() {
+            let _ = update.send_request(rpc_client).await?;
+            update.update_status(logger, i, total);
+        }
+        Ok(())
+    }
+}

--- a/crates/txtx-test-utils/src/builders/parser.rs
+++ b/crates/txtx-test-utils/src/builders/parser.rs
@@ -46,25 +46,23 @@ pub fn extract_actions(blocks: &[ParsedBlock]) -> Vec<String> {
         .collect()
 }
 
-/// Find references to signers in content
-pub fn find_signer_references(content: &str) -> Vec<String> {
+/// Scan `content` for occurrences of any prefix in `prefixes` followed by an
+/// identifier (alphanumeric + `_`), returning the deduplicated, sorted list of
+/// identifiers found.
+fn extract_prefixed_idents(content: &str, prefixes: &[&str]) -> Vec<String> {
     let mut references = Vec::new();
 
-    // Simple regex-like pattern matching for signer.xxx
-    let patterns = ["signer.", "signers."];
-    for pattern in &patterns {
+    for pattern in prefixes {
         let mut search_from = 0;
         while let Some(pos) = content[search_from..].find(pattern) {
             let start = search_from + pos + pattern.len();
-
-            // Find the end of the identifier
             let rest = &content[start..];
             let end = rest.find(|c: char| !c.is_alphanumeric() && c != '_').unwrap_or(rest.len());
 
             if end > 0 {
-                let signer_name = &rest[..end];
-                if !signer_name.is_empty() {
-                    references.push(signer_name.to_string());
+                let ident = &rest[..end];
+                if !ident.is_empty() {
+                    references.push(ident.to_string());
                 }
             }
 
@@ -77,60 +75,17 @@ pub fn find_signer_references(content: &str) -> Vec<String> {
     references
 }
 
-/// Find references to actions in content
-pub fn find_action_references(content: &str) -> Vec<String> {
-    let mut references = Vec::new();
-
-    // Simple pattern matching for action.xxx
-    let pattern = "action.";
-    let mut search_from = 0;
-    while let Some(pos) = content[search_from..].find(pattern) {
-        let start = search_from + pos + pattern.len();
-
-        // Find the action name (first identifier)
-        let rest = &content[start..];
-        let end = rest.find(|c: char| !c.is_alphanumeric() && c != '_').unwrap_or(rest.len());
-
-        if end > 0 {
-            let action_name = &rest[..end];
-            if !action_name.is_empty() {
-                references.push(action_name.to_string());
-            }
-        }
-
-        search_from = start + end;
-    }
-
-    references.sort();
-    references.dedup();
-    references
+/// Find references to signers in content (e.g., `signer.my_key`, `signers.my_key`).
+pub fn find_signer_references(content: &str) -> Vec<String> {
+    extract_prefixed_idents(content, &["signer.", "signers."])
 }
 
-/// Find all environment variable references in the content (e.g., env.API_KEY)
+/// Find references to actions in content (e.g., `action.deploy`).
+pub fn find_action_references(content: &str) -> Vec<String> {
+    extract_prefixed_idents(content, &["action."])
+}
+
+/// Find environment variable references in content (e.g., `env.API_KEY`).
 pub fn find_env_references(content: &str) -> Vec<String> {
-    let mut references = Vec::new();
-
-    // Simple pattern matching for env.xxx
-    let pattern = "env.";
-    let mut search_from = 0;
-    while let Some(pos) = content[search_from..].find(pattern) {
-        let start = search_from + pos + pattern.len();
-
-        // Find the env var name (identifier)
-        let rest = &content[start..];
-        let end = rest.find(|c: char| !c.is_alphanumeric() && c != '_').unwrap_or(rest.len());
-
-        if end > 0 {
-            let env_var = &rest[..end];
-            if !env_var.is_empty() {
-                references.push(env_var.to_string());
-            }
-        }
-
-        search_from = start + end;
-    }
-
-    references.sort();
-    references.dedup();
-    references
+    extract_prefixed_idents(content, &["env."])
 }


### PR DESCRIPTION
### What this PR is

A walk through what [rust-scope](https://github.com/cds-rs/rs-scope) surfaces when you point its MCP server at this workspace. rust-scope is a Rust static-analysis tool that builds a syn-resolved call graph of the project and answers structural questions about it: "which functions share a callee set," "which two-hop call chains recur," "what tripwires does `.scope-rules.toml` catch." For this pass I ran the primary DRY queries (`find_shared_callee_clones` and `find_recurring_call_chains`), read the top hits in source, and sorted true signals from coincidences of shape. Three findings cleared the bar; this PR implements all three.

Each commit is self-contained and labels the rust-scope signal that surfaced it, so you can review them independently (and, if you only trust one class of change, cherry-pick).

### Commits

| # | Scope | Surfaced by | Net |
|---|-------|-------------|-----|
| 1 | `addons/svm/core/src/commands/setup_surfnet/*` | `find_shared_callee_clones` (two 6-member groups) | -79 lines |
| 2 | `addons/evm/src/typing.rs` | `find_shared_callee_clones` (3-member group) | -25 lines |
| 3 | `crates/txtx-test-utils/src/builders/parser.rs` | `find_shared_callee_clones` (3-member group) | -45 lines |

(Net lines count new helpers/traits; net "duplicated code removed" is larger.)

### 1. `refactor(svm): extract SurfnetAccountUpdate trait`

**What the tool saw.** Two groups of six members each. The first grouped six functions named `process_updates` across sibling files; the second grouped the six `send_request` functions they each called. The tool flags this as "these functions share a callee set, which is the primary DRY signal."

**What I found in source.** Six distinct types under `commands/setup_surfnet/` (`SurfpoolAccountUpdate`, `SurfpoolTokenAccountUpdate`, `SurfpoolProgramCloning`, `SurfpoolSetProgramAuthority`, `SurfpoolResetAccount`, `SurfpoolStreamAccount`) each carrying a five-method contract:

```rust
fn rpc_method() -> &'static str        // differs
fn to_request_params(&self) -> Value   // differs
fn update_status(&self, ..., ...)      // differs (string literals only)
async fn send_request(&self, ...)      // IDENTICAL
async fn process_updates(Vec<Self>, ...) // IDENTICAL
```

I diffed `stream_account.rs:112-135`, `reset_account.rs:112-135`, and `set_account.rs:614-637` side-by-side: `send_request` and `process_updates` are byte-for-byte identical modulo the enclosing type. Classic missing-trait.

**The fix.** A new `surfnet_update` module with a `SurfnetAccountUpdate` trait whose default methods hold the identical bodies; each of the six types implements only the three methods that genuinely vary. The callers in `mod.rs` already used the `Type::process_updates(...)` turbofish-style call, so nothing at the call sites had to change (just a `use surfnet_update::SurfnetAccountUpdate;` to bring the trait into scope).

**Remark: why `cheatcode_deploy_program` stays out.** It has a `process_updates` too, so a naive eye might include it in the refactor. But its body is genuinely different: it calls a free function `cheatcode_deploy_program(...)` instead of `send_request`, and it conditionally makes a second RPC call to register an IDL. Forcing it under the trait would either require a more permissive trait shape (looser default, more abstract methods) or a special-case override inside it. Neither pays for itself with only one outlier, so I left it alone. The tool didn't flag it either, which is the tool working correctly.

**N.B. on `async fn` in traits.** The trait uses native `async fn` in traits (stable since Rust 1.75). The well-known gotcha is that the returned future isn't `Send` by default, which can break callers that need to `tokio::spawn` the future across threads. The six call sites in `setup_surfnet/mod.rs` all `.await` immediately inside the owning async function (no spawning), so this is fine in practice. Full `cargo check --workspace --tests` passes. If a future caller does need `Send`, the trait can be upgraded to `#[async_trait]` or to explicit `-> impl Future + Send` return types without changing the call sites.

**Files touched.** Six siblings under `setup_surfnet/`, plus `mod.rs` (new module declaration) and `codec/utils.rs` (adds `use` for the trait so its two existing `.send_request()` calls still resolve).

### 2. `refactor(evm): collapse to_* addon decoders into decode_addon_bytes<T>`

**What the tool saw.** A 3-member clone group: `to_known_sol_param`, `to_foundry_compiled_metadata`, `to_foundry_bytecode_data`, all sharing the same callee set (`as_addon_data`, `Err`, `Ok`, `map_err`, `ok_or_else`, `serde_json::from_slice`).

**What I found in source.** Each function ran the same four-step recipe:

1. Unwrap `value.as_addon_data()` or return a "not an addon data type" error.
2. Check `addon_data.id == <constant>` or return a type-mismatch error.
3. `serde_json::from_slice(&addon_data.bytes)` to get `T`.
4. Map the deserializer error through the same `err_msg` prefix.

The only variation per function was the expected id constant and the target deserialization type. That's a generic, not three functions.

**The fix.** A private `decode_addon_bytes<T: DeserializeOwned>(value, expected_id, what) -> Result<T, Diagnostic>` in the same module. Each `to_*` collapses to:

```rust
pub fn to_foundry_compiled_metadata(value: &Value) -> Result<Metadata, Diagnostic> {
    decode_addon_bytes(value, EVM_FOUNDRY_COMPILED_METADATA, "foundry metadata")
}
```

**A bonus find the tool didn't call out.** While I was in the file, I noticed `to_sim_result` (line 130) follows the same skeleton for its first decode, then adds custom logic to deserialize an optional nested `Function`. The tool missed this because its inner decode has an extra intermediate variable and its callee set was just slightly different. I refactored it partially: the first decode uses the helper; the custom tail stays. This is what "true signal" should do for reviewers, point you at the *kind* of duplication, then you look around for other instances.

**What's preserved.** The error message strings are preserved verbatim, including the unusual "expected type {EVM_FOOBAR}, got {addon_data.id}" format; `decode_addon_bytes` constructs them from `expected_id` and `what` in the same way. I reread the originals against the new messages byte-by-byte to confirm; see the commit diff.

**Files touched.** Just `addons/evm/src/typing.rs`.

### 3. `refactor(test-utils): collapse find_*_references into extract_prefixed_idents`

**What the tool saw.** A 3-member clone group: `find_signer_references`, `find_action_references`, `find_env_references`, each calling the same grab-bag of string helpers (`find`, `is_alphanumeric`, `push`, `dedup`, `sort`, `to_string`).

**What I found in source.** A scan-for-prefix loop, duplicated three times, differing only in the prefix set: `["signer.", "signers."]`, `["action."]`, `["env."]`. The algorithm (find the prefix, consume trailing `[A-Za-z0-9_]+`, push to results, dedup+sort) was identical.

**The fix.** A private `extract_prefixed_idents(content: &str, prefixes: &[&str]) -> Vec<String>` helper holds the loop; the three public functions are one-liners that supply their prefix list.

**Verification.** This module is covered by `crates/txtx-test-utils/tests/test_parser.rs`, which has a dedicated test per function (`test_find_signer_references`, `test_find_action_references`, `test_find_env_references`). All three pass unchanged. That's the reviewer's easiest path: no need to re-audit the loop logic by eye, the existing tests assert the extracted helper behaves identically.

**Files touched.** Just `crates/txtx-test-utils/src/builders/parser.rs`.

### Scope: what I deliberately did not change

Worth surfacing, since a reviewer might wonder. rust-scope flagged several other groups that I investigated and rejected as false positives:

| Flagged | Why I skipped |
|---------|---------------|
| `action_blocks` / `modal_blocks` / `error_blocks` in `txtx-gql/src/query.rs` | GraphQL resolver pattern; the shape is forced by the juniper trait. |
| `visit_define_private` / `visit_define_public` / `visit_define_read_only` in `txtx-lsp` | Visitor pattern mandated by the `Visit` trait; no abstraction to extract. |
| `arbitrary_map_*` tests in `map_eval_tests.rs` | The common prelude is *already* factored into `make_contexts` / `parse_blocks`. Tool was flagging the shared helpers themselves, which is the success state. |
| Top recurring call chains bottoming in `to_string` / `collect` / `from` / `into` | Type-forced conversion glue, not duplication. |

I think these are good examples of the cognitive work rust-scope *doesn't* do for you; it flags shape, and you judge whether the shape corresponds to a missing abstraction or to a legitimate framework-imposed pattern.

### Verification

Run locally (matches what CI will run):

```bash
# Workspace check (don't build supervisor UI locally, unless you have superpowers).
cargo check --workspace --no-default-features --features cli --tests

# Targeted tests for the three touched packages.
cargo test -p txtx-addon-network-svm \
           -p txtx-addon-network-evm \
           -p txtx-test-utils \
           --no-default-features
```

Both passed cleanly on this branch. Warnings in the output are pre-existing (lifetime elision suggestions in `txtx-addon-kit`, a deprecated `solana-loader-v3-interface` function in `codec/mod.rs`); none were introduced by this PR.

### How to review

If you trust the framing, the fastest review path is:

1. Read commit 1's diff for **one** of the six `setup_surfnet/*` files (any will do; they were all the same shape). Then skim the other five diffs to confirm they're the same kind of edit. Read `surfnet_update.rs` in full (it's ~45 lines).
2. For commit 2, the meat is `decode_addon_bytes` plus the four call sites; the error-message preservation is the only subtle bit.
3. For commit 3, just check that the extracted helper matches the loop it replaced, then note that `test_parser.rs` already covers behavioral equivalence.

Happy to split this into three PRs if that's preferred; each commit is independent and none of the packages depends on another's change for its build.
