### PR TITLE
refactor(evm): remove dead spinner code in check_confirmations (#157)

### DIFF
--- a/addons/evm/src/commands/actions/check_confirmations.rs
+++ b/addons/evm/src/commands/actions/check_confirmations.rs
@@ -178,16 +178,11 @@ impl CommandImplementation for CheckEvmConfirmations {
         let tx_hash_bytes = inputs.get_expected_buffer_bytes(TX_HASH)?;
         let rpc_api_url = inputs.get_expected_string(RPC_API_URL)?.to_owned();
 
-        let progress_symbol = ["|", "/", "-", "\\", "|", "/", "-", "\\"];
-
         let tx_hash = hex::encode(&tx_hash_bytes);
         let receipt_msg = format!("Checking Tx 0x{} Receipt on Chain {}", &tx_hash, chain_name);
 
         let future = async move {
             // initial progress status
-
-            let mut progress = 0;
-
             logger.pending_info("Pending", receipt_msg);
 
             let mut result = CommandExecutionResult::new();
@@ -200,8 +195,6 @@ impl CommandImplementation for CheckEvmConfirmations {
             let mut current_block = 0;
             let mut previous_block = 0;
             let _receipt = loop {
-                progress = (progress + 1) % progress_symbol.len();
-
                 let Some(receipt) = rpc.get_receipt(&tx_hash_bytes).await.map_err(|e| {
                     diagnosed_error!("failed to verify transaction {}: {}", tx_hash, e)
                 })?


### PR DESCRIPTION
## Summary

Closes #157 (progress-bar portion).

Issue #157 asked to replace the verbose "mutable status struct → send → mutate → resend"
pattern with a clean status helper. In this fork that migration was **already completed**
via `LogDispatcher`, and `evm::check_confirmations` already uses it. This PR removes the
last leftover of the old pattern: dead manual-spinner state.

The `stacks` and `sp1` addons referenced in the original issue no longer exist in this
fork, so the only applicable target file is `check_confirmations.rs`.

## Changes

- Remove `progress_symbol` array, `let mut progress = 0`, and the per-iteration
  `progress = (progress + 1) % progress_symbol.len()` from
  `addons/evm/src/commands/actions/check_confirmations.rs`.

## Verification

- `cargo build -p txtx-addon-network-evm` passes with no new warnings.
- Loop control flow and command outputs are unchanged.