### PR TITLE
fix(kit): nest array type when converting string to Type (cleanup)

### DIFF
--- a/crates/txtx-addon-kit/src/types/tests/mod.rs
+++ b/crates/txtx-addon-kit/src/types/tests/mod.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use crate::helpers::fs::FileLocation;
 use crate::types::AuthorizationContext;
 
-use super::types::Value;
+use super::types::{ObjectDefinition, Type, Value};
 use serde_json::json;
 use serde_json::Value as JsonValue;
 use test_case::test_case;
@@ -35,6 +35,36 @@ fn it_serdes_values(value: Value) {
     let de: Value = serde_json::from_str(&ser).unwrap();
     println!("deserialized:  {:?}\n", de);
     assert_eq!(de, value);
+}
+
+#[test_case(Type::string())]
+#[test_case(Type::integer())]
+#[test_case(Type::float())]
+#[test_case(Type::bool())]
+#[test_case(Type::buffer())]
+#[test_case(Type::null())]
+#[test_case(Type::typed_null(Type::integer()))]
+#[test_case(Type::typed_null(Type::typed_null(Type::integer())); "nested typed null")]
+#[test_case(Type::array(Type::integer()))]
+#[test_case(Type::array(Type::array(Type::string())); "nested array")]
+#[test_case(Type::array(Type::typed_null(Type::integer())); "array of typed null")]
+#[test_case(Type::addon("ns::type"))]
+#[test_case(Type::array(Type::addon("ns::type")); "array of addon")]
+#[test_case(Type::object(ObjectDefinition::arbitrary()))]
+#[test_case(Type::map(ObjectDefinition::arbitrary()))]
+#[test_case(Type::array(Type::map(ObjectDefinition::arbitrary())); "array of map")]
+fn it_serdes_types(typing: Type) {
+    let ser = serde_json::to_string(&typing).unwrap();
+    let de: Type = serde_json::from_str(&ser).unwrap();
+    assert_eq!(de, typing);
+}
+
+#[test_case("array[integer"; "unterminated array")]
+#[test_case("addon(ns::type"; "unterminated addon")]
+#[test_case("null<integer"; "unterminated null")]
+#[test_case("array[nope]"; "array of invalid type")]
+fn it_rejects_malformed_type_strings(s: &str) {
+    assert!(Type::try_from(s.to_string()).is_err(), "expected error for {:?}", s);
 }
 
 #[test_case(json!({"type": "integer", "value": "1" }))]

--- a/crates/txtx-addon-kit/src/types/types.rs
+++ b/crates/txtx-addon-kit/src/types/types.rs
@@ -1325,7 +1325,7 @@ impl TryFrom<String> for Type {
                 } else if other.starts_with("array[") && other.ends_with("]") {
                     let mut inner = other.replace("array[", "");
                     inner = inner.replace("]", "");
-                    return Type::try_from(inner);
+                    return Ok(Type::array(Type::try_from(inner)?));
                 } else if other.starts_with("addon(") {
                     let mut inner = other.replace("addon(", "");
                     inner = inner.replace(")", "");

--- a/crates/txtx-addon-kit/src/types/types.rs
+++ b/crates/txtx-addon-kit/src/types/types.rs
@@ -1313,22 +1313,23 @@ impl TryFrom<String> for Type {
             "bool" => Type::Bool,
             "buffer" => Type::Buffer,
             "object" => Type::Object(ObjectDefinition::arbitrary()),
+            "map" => Type::Map(ObjectDefinition::arbitrary()),
             other => {
                 if other == "null" {
                     return Ok(Type::null());
                 }
-                if other.starts_with("null<") && other.ends_with(">") {
-                    let mut inner = other.replace("null<", "");
-                    inner = inner.replace(">", "");
-                    let inner_type = Type::try_from(inner)?;
+                if let Some(inner) = other.strip_prefix("null<").and_then(|s| s.strip_suffix(">"))
+                {
+                    let inner_type = Type::try_from(inner.to_string())?;
                     return Ok(Type::typed_null(inner_type));
-                } else if other.starts_with("array[") && other.ends_with("]") {
-                    let inner = &other["array[".len()..other.len() - 1];
+                } else if let Some(inner) =
+                    other.strip_prefix("array[").and_then(|s| s.strip_suffix("]"))
+                {
                     return Ok(Type::array(Type::try_from(inner.to_string())?));
-                } else if other.starts_with("addon(") {
-                    let mut inner = other.replace("addon(", "");
-                    inner = inner.replace(")", "");
-                    Type::addon(&inner)
+                } else if let Some(inner) =
+                    other.strip_prefix("addon(").and_then(|s| s.strip_suffix(")"))
+                {
+                    Type::addon(inner)
                 } else {
                     return Err(format!("invalid type: {}", other));
                 }

--- a/crates/txtx-addon-kit/src/types/types.rs
+++ b/crates/txtx-addon-kit/src/types/types.rs
@@ -1323,9 +1323,8 @@ impl TryFrom<String> for Type {
                     let inner_type = Type::try_from(inner)?;
                     return Ok(Type::typed_null(inner_type));
                 } else if other.starts_with("array[") && other.ends_with("]") {
-                    let mut inner = other.replace("array[", "");
-                    inner = inner.replace("]", "");
-                    return Ok(Type::array(Type::try_from(inner)?));
+                    let inner = &other["array[".len()..other.len() - 1];
+                    return Ok(Type::array(Type::try_from(inner.to_string())?));
                 } else if other.starts_with("addon(") {
                     let mut inner = other.replace("addon(", "");
                     inner = inner.replace(")", "");


### PR DESCRIPTION
Follow up to #375

- add tests to validate roundtrip encode/decode
- include map in decode logic

## Tests

<details> <summary> FAILING TESTS (Click me... do it. clicky clicky)</summary>

<strong>You clicked! thank you</strong>

```console
---- types::tests::it_rejects_malformed_type_strings::unterminated_addon stdout ----

thread 'types::tests::it_rejects_malformed_type_strings::unterminated_addon' panicked at crates/txtx-addon-kit/src/types/tests/mod.rs:67:5:
expected error for "addon(ns::type"
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- types::tests::it_serdes_types::array_of_map stdout ----

thread 'types::tests::it_serdes_types::array_of_map' panicked at crates/txtx-addon-kit/src/types/tests/mod.rs:58:47:
called `Result::unwrap()` on an `Err` value: Error("invalid type: map", line: 0, column: 0)

---- types::tests::it_serdes_types::nested_typed_null stdout ----

thread 'types::tests::it_serdes_types::nested_typed_null' panicked at crates/txtx-addon-kit/src/types/tests/mod.rs:59:5:
assertion `left == right` failed
  left: Null(Some(Integer))
 right: Null(Some(Null(Some(Integer))))

---- types::tests::it_serdes_types::type_map_objectdefinition_arbitrary_expects stdout ----

thread 'types::tests::it_serdes_types::type_map_objectdefinition_arbitrary_expects' panicked at crates/txtx-addon-kit/src/types/tests/mod.rs:58:47:
called `Result::unwrap()` on an `Err` value: Error("invalid type: map", line: 0, column: 0)


failures:
    types::tests::it_rejects_malformed_type_strings::unterminated_addon
    types::tests::it_serdes_types::array_of_map
    types::tests::it_serdes_types::nested_typed_null
    types::tests::it_serdes_types::type_map_objectdefinition_arbitrary_expects


error: test failed, to rerun pass `-p txtx-addon-kit --lib`
```

</details>


## Passing Test run 2

```console
running 26 tests
... snip ...
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 30 filtered out; finished in 0.00s
```
