### PR TITLE
fix: remove unused `commitment_level` and `rpc_api_auth_token` fields from actions

### DIFF
--- a/addons/svm/core/src/commands/deploy_token.rs
+++ b/addons/svm/core/src/commands/deploy_token.rs
@@ -754,7 +754,6 @@ mod tests {
         assert!(!input_names.contains(&"mint_keypair".to_string()));
         assert!(!input_names.contains(&"mint".to_string()));
         assert!(!input_names.contains(&"rpc_api_url".to_string()));
-        assert!(!input_names.contains(&"rpc_api_auth_token".to_string()));
         assert!(!deploy_token_input_optional(PAYER));
         assert!(deploy_token_input_optional(AUTHORITY));
     }

--- a/addons/svm/core/src/commands/process_instructions.rs
+++ b/addons/svm/core/src/commands/process_instructions.rs
@@ -62,6 +62,14 @@ lazy_static! {
                         internal: false,
                         sensitive: false
                     },
+                    commitment_level: {
+                        documentation: "The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.",
+                        typing: Type::string(),
+                        optional: true,
+                        tainting: false,
+                        internal: false,
+                        sensitive: false
+                    },
                     rpc_api_url: {
                         documentation: "The URL to use when making API requests.",
                         typing: Type::string(),

--- a/addons/svm/core/src/commands/process_instructions.rs
+++ b/addons/svm/core/src/commands/process_instructions.rs
@@ -62,14 +62,6 @@ lazy_static! {
                         internal: false,
                         sensitive: false
                     },
-                    commitment_level: {
-                        documentation: "The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.",
-                        typing: Type::string(),
-                        optional: true,
-                        tainting: false,
-                        internal: false,
-                        sensitive: false
-                    },
                     rpc_api_url: {
                         documentation: "The URL to use when making API requests.",
                         typing: Type::string(),
@@ -77,14 +69,6 @@ lazy_static! {
                         tainting: false,
                         internal: false,
                         sensitive: false
-                    },
-                    rpc_api_auth_token: {
-                        documentation: "The HTTP authentication token to include in the headers when making API requests.",
-                        typing: Type::string(),
-                        optional: true,
-                        tainting: false,
-                        internal: false,
-                        sensitive: true
                     },
                     skip_preflight: {
                         documentation: "Whether to skip preflight checks. The default is `false`.",

--- a/addons/svm/core/src/commands/send_sol.rs
+++ b/addons/svm/core/src/commands/send_sol.rs
@@ -71,6 +71,14 @@ lazy_static! {
                     internal: false,
                     sensitive: false
                 },
+                commitment_level: {
+                    documentation: "The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.",
+                    typing: Type::string(),
+                    optional: true,
+                    tainting: false,
+                    internal: false,
+                    sensitive: false
+                },
                 rpc_api_url: {
                     documentation: "The URL to use when making API requests.",
                     typing: Type::string(),
@@ -78,7 +86,7 @@ lazy_static! {
                     tainting: false,
                     internal: false,
                     sensitive: false
-                }          
+                }
             ],
             outputs: [
                 signature: {

--- a/addons/svm/core/src/commands/send_sol.rs
+++ b/addons/svm/core/src/commands/send_sol.rs
@@ -71,14 +71,6 @@ lazy_static! {
                     internal: false,
                     sensitive: false
                 },
-                commitment_level: {
-                    documentation: "The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.",
-                    typing: Type::string(),
-                    optional: true,
-                    tainting: false,
-                    internal: false,
-                    sensitive: false
-                },
                 rpc_api_url: {
                     documentation: "The URL to use when making API requests.",
                     typing: Type::string(),
@@ -86,15 +78,7 @@ lazy_static! {
                     tainting: false,
                     internal: false,
                     sensitive: false
-                },
-                rpc_api_auth_token: {
-                    documentation: "The HTTP authentication token to include in the headers when making API requests.",
-                    typing: Type::string(),
-                    optional: true,
-                    tainting: false,
-                    internal: false,
-                    sensitive: true
-                }
+                }          
             ],
             outputs: [
                 signature: {

--- a/addons/svm/core/src/commands/send_token.rs
+++ b/addons/svm/core/src/commands/send_token.rs
@@ -98,14 +98,6 @@ lazy_static! {
                     internal: false,
                     sensitive: false
                 },
-                commitment_level: {
-                    documentation: "The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.",
-                    typing: Type::string(),
-                    optional: true,
-                    tainting: false,
-                    internal: false,
-                    sensitive: false
-                },
                 rpc_api_url: {
                     documentation: "The URL to use when making API requests.",
                     typing: Type::string(),
@@ -113,14 +105,6 @@ lazy_static! {
                     tainting: false,
                     internal: false,
                     sensitive: false
-                },
-                rpc_api_auth_token: {
-                    documentation: "The HTTP authentication token to include in the headers when making API requests.",
-                    typing: Type::string(),
-                    optional: true,
-                    tainting: false,
-                    internal: false,
-                    sensitive: true
                 }
             ],
             outputs: [

--- a/addons/svm/core/src/commands/send_token.rs
+++ b/addons/svm/core/src/commands/send_token.rs
@@ -98,6 +98,14 @@ lazy_static! {
                     internal: false,
                     sensitive: false
                 },
+                commitment_level: {
+                    documentation: "The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.",
+                    typing: Type::string(),
+                    optional: true,
+                    tainting: false,
+                    internal: false,
+                    sensitive: false
+                },
                 rpc_api_url: {
                     documentation: "The URL to use when making API requests.",
                     typing: Type::string(),

--- a/addons/svm/core/src/commands/srs/create_class.rs
+++ b/addons/svm/core/src/commands/srs/create_class.rs
@@ -148,14 +148,6 @@ lazy_static! {
                         tainting: false,
                         internal: false,
                         sensitive: false
-                    },
-                    rpc_api_auth_token: {
-                        documentation: "The HTTP authentication token to include in the headers when making API requests.",
-                        typing: Type::string(),
-                        optional: true,
-                        tainting: false,
-                        internal: false,
-                        sensitive: true
                     }
                 ],
                 outputs: [

--- a/addons/svm/core/src/commands/srs/create_record.rs
+++ b/addons/svm/core/src/commands/srs/create_record.rs
@@ -159,14 +159,6 @@ lazy_static! {
                         tainting: false,
                         internal: false,
                         sensitive: false
-                    },
-                    rpc_api_auth_token: {
-                        documentation: "The HTTP authentication token to include in the headers when making API requests.",
-                        typing: Type::string(),
-                        optional: true,
-                        tainting: false,
-                        internal: false,
-                        sensitive: true
                     }
                 ],
                 outputs: [

--- a/doc/addons/actions.json
+++ b/doc/addons/actions.json
@@ -662,23 +662,11 @@
           "optional": false
         },
         {
-          "name": "commitment_level",
-          "documentation": "The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.",
-          "typing": "string",
-          "optional": true
-        },
-        {
           "name": "rpc_api_url",
           "documentation": "The URL to use when making API requests.",
           "typing": "string",
           "optional": false
-        },
-        {
-          "name": "rpc_api_auth_token",
-          "documentation": "The HTTP authentication token to include in the headers when making API requests.",
-          "typing": "string",
-          "optional": true
-        }
+        }     
       ],
       "outputs": [
         {
@@ -803,22 +791,10 @@
           "optional": false
         },
         {
-          "name": "commitment_level",
-          "documentation": "The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.",
-          "typing": "string",
-          "optional": true
-        },
-        {
           "name": "rpc_api_url",
           "documentation": "The URL to use when making API requests.",
           "typing": "string",
           "optional": false
-        },
-        {
-          "name": "rpc_api_auth_token",
-          "documentation": "The HTTP authentication token to include in the headers when making API requests.",
-          "typing": "string",
-          "optional": true
         }
       ],
       "outputs": [
@@ -878,22 +854,10 @@
           "optional": false
         },
         {
-          "name": "commitment_level",
-          "documentation": "The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.",
-          "typing": "string",
-          "optional": true
-        },
-        {
           "name": "rpc_api_url",
           "documentation": "The URL to use when making API requests.",
           "typing": "string",
           "optional": false
-        },
-        {
-          "name": "rpc_api_auth_token",
-          "documentation": "The HTTP authentication token to include in the headers when making API requests.",
-          "typing": "string",
-          "optional": true
         }
       ],
       "outputs": [
@@ -1092,12 +1056,6 @@
           "documentation": "The URL to use when making API requests.",
           "typing": "string",
           "optional": false
-        },
-        {
-          "name": "rpc_api_auth_token",
-          "documentation": "The HTTP authentication token to include in the headers when making API requests.",
-          "typing": "string",
-          "optional": true
         }
       ],
       "outputs": [
@@ -1182,12 +1140,6 @@
           "documentation": "The URL to use when making API requests.",
           "typing": "string",
           "optional": false
-        },
-        {
-          "name": "rpc_api_auth_token",
-          "documentation": "The HTTP authentication token to include in the headers when making API requests.",
-          "typing": "string",
-          "optional": true
         }
       ],
       "outputs": [

--- a/doc/addons/actions.json
+++ b/doc/addons/actions.json
@@ -662,11 +662,17 @@
           "optional": false
         },
         {
+          "name": "commitment_level",
+          "documentation": "The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.",
+          "typing": "string",
+          "optional": true
+        },
+        {
           "name": "rpc_api_url",
           "documentation": "The URL to use when making API requests.",
           "typing": "string",
           "optional": false
-        }     
+        }
       ],
       "outputs": [
         {
@@ -791,6 +797,12 @@
           "optional": false
         },
         {
+          "name": "commitment_level",
+          "documentation": "The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.",
+          "typing": "string",
+          "optional": true
+        },
+        {
           "name": "rpc_api_url",
           "documentation": "The URL to use when making API requests.",
           "typing": "string",
@@ -852,6 +864,12 @@
           "documentation": "A set of references to signer constructs, which will be used to sign the transaction.",
           "typing": "array[string]",
           "optional": false
+        },
+        {
+          "name": "commitment_level",
+          "documentation": "The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.",
+          "typing": "string",
+          "optional": true
         },
         {
           "name": "rpc_api_url",

--- a/doc/addons/svm/actions/page.mdx
+++ b/doc/addons/svm/actions/page.mdx
@@ -36,18 +36,8 @@ The `svm::process_instructions` action encodes instructions, adds them to a tran
   </Property>
 
 
-  <Property name="commitment_level" required="optional" type="string">
-    The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.
-  </Property>
-
-
   <Property name="rpc_api_url" required="required" type="string">
     The URL to use when making API requests.
-  </Property>
-
-
-  <Property name="rpc_api_auth_token" required="optional" type="string">
-    The HTTP authentication token to include in the headers when making API requests.
   </Property>
 
 
@@ -311,18 +301,8 @@ The `svm::send_sol` action encodes a transaction which sends SOL, signs it, and 
   </Property>
 
 
-  <Property name="commitment_level" required="optional" type="string">
-    The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.
-  </Property>
-
-
   <Property name="rpc_api_url" required="required" type="string">
     The URL to use when making API requests.
-  </Property>
-
-
-  <Property name="rpc_api_auth_token" required="optional" type="string">
-    The HTTP authentication token to include in the headers when making API requests.
   </Property>
 
 
@@ -445,18 +425,8 @@ The `svm::send_token` action encodes a transaction which sends the specified tok
   </Property>
 
 
-  <Property name="commitment_level" required="optional" type="string">
-    The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.
-  </Property>
-
-
   <Property name="rpc_api_url" required="required" type="string">
     The URL to use when making API requests.
-  </Property>
-
-
-  <Property name="rpc_api_auth_token" required="optional" type="string">
-    The HTTP authentication token to include in the headers when making API requests.
   </Property>
 
 
@@ -968,11 +938,6 @@ The `svm::create_class` action is coming soon.
   </Property>
 
 
-  <Property name="rpc_api_auth_token" required="optional" type="string">
-    The HTTP authentication token to include in the headers when making API requests.
-  </Property>
-
-
   <Property name="pre_condition" required="optional" type="map">
     Pre-conditions are assertions that are evaluated before a command is executed. They can be used to determine if the command should be executed or if a specific behavior should be executed based on the result of the assertion. This is a map type containing the keys:
   - **behavior**: The behavior if the pre-condition assertion does not pass. Possible values are:
@@ -1116,11 +1081,6 @@ The `svm::create_record` action is coming soon.
 
   <Property name="rpc_api_url" required="required" type="string">
     The URL to use when making API requests.
-  </Property>
-
-
-  <Property name="rpc_api_auth_token" required="optional" type="string">
-    The HTTP authentication token to include in the headers when making API requests.
   </Property>
 
 

--- a/doc/addons/svm/actions/page.mdx
+++ b/doc/addons/svm/actions/page.mdx
@@ -36,6 +36,11 @@ The `svm::process_instructions` action encodes instructions, adds them to a tran
   </Property>
 
 
+  <Property name="commitment_level" required="optional" type="string">
+    The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.
+  </Property>
+
+
   <Property name="rpc_api_url" required="required" type="string">
     The URL to use when making API requests.
   </Property>
@@ -301,6 +306,11 @@ The `svm::send_sol` action encodes a transaction which sends SOL, signs it, and 
   </Property>
 
 
+  <Property name="commitment_level" required="optional" type="string">
+    The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.
+  </Property>
+
+
   <Property name="rpc_api_url" required="required" type="string">
     The URL to use when making API requests.
   </Property>
@@ -422,6 +432,11 @@ The `svm::send_token` action encodes a transaction which sends the specified tok
 
   <Property name="signers" required="required" type="array[string]">
     A set of references to signer constructs, which will be used to sign the transaction.
+  </Property>
+
+
+  <Property name="commitment_level" required="optional" type="string">
+    The commitment level expected for considering this action as done ('processed', 'confirmed', 'finalized'). The default is 'confirmed'.
   </Property>
 
 
@@ -1178,4 +1193,3 @@ action "my_record" "svm::create_record" {
 </CodeGroup>
 
 ---
-


### PR DESCRIPTION
Closes #415 

Removes 100% unused `commitment_level` + `rpc_api_auth_token`

There are some other actions that still technically use it, but maybe they could also be removed. Such as the command `deploy_program`